### PR TITLE
feat: allow gitlab ref to be defined by env

### DIFF
--- a/siibra/config.py
+++ b/siibra/config.py
@@ -16,13 +16,14 @@ import json
 from . import logger,__version__
 from .commons import create_key
 from gitlab import Gitlab
+import os
 
 # Until openminds is fully supported, 
 # we store atlas configurations in a gitlab repo.
 # We tag the configuration with each release
 GITLAB_SERVER = 'https://jugit.fz-juelich.de'
 GITLAB_PROJECT_ID=3484
-GITLAB_PROJECT_TAG="siibra-{}".format(__version__)
+GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG", "siibra-{}".format(__version__))
 
 class ConfigurationRegistry:
     """

--- a/siibra/config.py
+++ b/siibra/config.py
@@ -25,6 +25,9 @@ GITLAB_SERVER = 'https://jugit.fz-juelich.de'
 GITLAB_PROJECT_ID=3484
 GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG", "siibra-{}".format(__version__))
 
+if "SIIBRA_CONFIG_GITLAB_PROJECT_TAG" in os.environ:
+    logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")
+
 class ConfigurationRegistry:
     """
     Registers atlas configurations from json files managed in EBRAINS, by

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest import mock, TestCase
+import os
+import importlib
+import siibra
+
+class TestConfig1(TestCase):
+
+    def test_exported_variable(self):
+        self.assertEqual(
+            siibra.config.GITLAB_PROJECT_TAG,
+            f"siibra-{siibra.__version__}"
+        )
+
+    @mock.patch.dict(os.environ, { 'SIIBRA_CONFIG_GITLAB_PROJECT_TAG': 'develop' }, clear=True)
+    def test_when_env_set(self):
+
+        importlib.reload(siibra)
+        importlib.reload(siibra.config)
+        self.assertEqual(
+            siibra.config.GITLAB_PROJECT_TAG,
+            "develop"
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
default/fallback is siibra-{__version__} per HEAD

env key is `SIIBRA_CONFIG_GITLAB_PROJECT_TAG` 

This should improve dev workflow. When developing against a specific ref, instead of explicitly update the ref in file, one can just define the env var