### PR TITLE
hotfix: added the ability to swap gitlab...

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.7', '3.6' ]
+        python-version: [ '3.8', '3.7' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -17,6 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
         python -m pip install -U .
     
     - name: cd to / and try to import

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ appdirs
 scikit-image
 click
 clint
-python-gitlab==2.6.0
+python-gitlab
 statsmodels
 cloud-volume
 memoization

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ appdirs
 scikit-image
 click
 clint
-python-gitlab
+python-gitlab==2.6.0
 statsmodels
 cloud-volume
 memoization

--- a/siibra/config.py
+++ b/siibra/config.py
@@ -21,9 +21,15 @@ import os
 # Until openminds is fully supported, 
 # we store atlas configurations in a gitlab repo.
 # We tag the configuration with each release
-GITLAB_SERVER = 'https://jugit.fz-juelich.de'
-GITLAB_PROJECT_ID=3484
+GITLAB_SERVER=os.getenv("SIIBRA_CONFIG_GITLAB_SERVER", 'https://jugit.fz-juelich.de')
+GITLAB_PROJECT_ID=os.getenv('SIIBRA_CONFIG_GITLAB_PROJECT_ID', 3484)
 GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG", "siibra-{}".format(__version__))
+
+if "SIIBRA_CONFIG_GITLAB_SERVER" in os.environ:
+    logger.warning(f"environ SIIBRA_CONFIG_GITLAB_SERVER set, using {GITLAB_SERVER} as GITLAB_SERVER")
+
+if "SIIBRA_CONFIG_GITLAB_PROJECT_ID" in os.environ:
+    logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_ID set, using {GITLAB_PROJECT_ID} as GITLAB_PROJECT_ID")
 
 if "SIIBRA_CONFIG_GITLAB_PROJECT_TAG" in os.environ:
     logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")


### PR DESCRIPTION
...server & projectid

similar to `GITLAB_PROJECT_TAG`, this PR allow developer to specify a mirror (in the event that a git remote is buggy / in testing environment)

- pin `python-gitlab` to v2.6.0 (https://github.com/python-gitlab/python-gitlab/issues/1416)
- drop python3.6 support (numpy 1.20 drops python3.6 support https://numpy.org/doc/stable/release/1.20.0-notes.html)