### PR TITLE
Enforce region decoding on feature extraction

### DIFF
--- a/examples/BigBrain.ipynb
+++ b/examples/BigBrain.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_roi(layers.as_image(),\"Layer masks\")"
+    "plot_roi(layers[0],\"Layer masks\")"
    ]
   },
   {
@@ -143,6 +143,13 @@
     "regionmask = atlas.build_mask(siibra.spaces.BIG_BRAIN,resolution=320)\n",
     "plot_roi(regionmask,\"Area hOc3v\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Probabilistic_assignment.ipynb
+++ b/examples/Probabilistic_assignment.ipynb
@@ -175,13 +175,6 @@
     "fig.gca().set_title(f\"Connection strengths from area {atlas.selected_region}\")\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Walkthrough.ipynb
+++ b/examples/Walkthrough.ipynb
@@ -48,9 +48,9 @@
    "source": [
     "import webbrowser\n",
     "from os import environ\n",
-    "webbrowser.open('https://nexus-iam.humanbrainproject.org/v0/oauth2/authorize')\n",
-    "token = input(\"Enter your token here: \")\n",
-    "environ['HBP_AUTH_TOKEN'] = token"
+    "#webbrowser.open('https://nexus-iam.humanbrainproject.org/v0/oauth2/authorize')\n",
+    "#token = input(\"Enter your token here: \")\n",
+    "environ['HBP_AUTH_TOKEN'] = \"eyJhbGciOiJSUzI1NiIsImtpZCI6ImJicC1vaWRjIn0.eyJleHAiOjE2MTk2MDI4NzcsInN1YiI6IjI1NTIzMCIsImF1ZCI6WyIzMjMxNDU3My1hMjQ1LTRiNWEtYjM3MS0yZjE1YWNjNzkxYmEiXSwiaXNzIjoiaHR0cHM6XC9cL3NlcnZpY2VzLmh1bWFuYnJhaW5wcm9qZWN0LmV1XC9vaWRjXC8iLCJqdGkiOiIwZDMzMTE0Zi1hZjI2LTQ2NGMtODQwNS05ZWIxMTEyMjkxZDciLCJpYXQiOjE2MTk1ODg0NzcsImhicF9rZXkiOiJiZjkwMzA3M2YzNjAzZDQ3ZTQ0NTRmOGY0YzlhYmE2MjdmM2MzNzVhIn0.Dgy7_vLBxuhRy-w28p3TzF09boZRvSD7sNwCiMkKBk6RtXuMlSh9xRGPL3CjWLxORd8lYp_ykqV8_Uj9ima_2XzViJgX1UrKXGLXWTxCbPlWs6ONJHmT8MWjd6jbzPInU55Sb75PAAFPq99ZPKzcLTPUk33CJCJbX1dOGvKgETI\""
    ]
   },
   {
@@ -85,7 +85,7 @@
    "source": [
     "import siibra\n",
     "siibra.logger.setLevel(\"INFO\") # show us some messages\n",
-    "# siibra.clear_cache()\n",
+    "#siibra.clear_cache()\n",
     "atlas = siibra.atlases.MULTILEVEL_HUMAN_ATLAS\n",
     "atlas.select_parcellation(siibra.parcellations.JULICH_BRAIN_CYTOARCHITECTONIC_MAPS_2_5)"
    ]
@@ -283,7 +283,7 @@
     "features = atlas.get_features(\n",
     "    siibra.modalities.ReceptorDistribution)\n",
     "print(\"Receptor density features found for the following regions:\")\n",
-    "print(\", \".join({f.region for f in features}))"
+    "print(\", \".join({f.region.name for f in features}))"
    ]
   },
   {
@@ -372,6 +372,13 @@
     "    axs[i].set_title(titleformat(feature.src_name),size=8)\n",
     "f.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Walkthrough.ipynb
+++ b/examples/Walkthrough.ipynb
@@ -50,7 +50,7 @@
     "from os import environ\n",
     "#webbrowser.open('https://nexus-iam.humanbrainproject.org/v0/oauth2/authorize')\n",
     "#token = input(\"Enter your token here: \")\n",
-    "environ['HBP_AUTH_TOKEN'] = \"eyJhbGciOiJSUzI1NiIsImtpZCI6ImJicC1vaWRjIn0.eyJleHAiOjE2MTk2MDI4NzcsInN1YiI6IjI1NTIzMCIsImF1ZCI6WyIzMjMxNDU3My1hMjQ1LTRiNWEtYjM3MS0yZjE1YWNjNzkxYmEiXSwiaXNzIjoiaHR0cHM6XC9cL3NlcnZpY2VzLmh1bWFuYnJhaW5wcm9qZWN0LmV1XC9vaWRjXC8iLCJqdGkiOiIwZDMzMTE0Zi1hZjI2LTQ2NGMtODQwNS05ZWIxMTEyMjkxZDciLCJpYXQiOjE2MTk1ODg0NzcsImhicF9rZXkiOiJiZjkwMzA3M2YzNjAzZDQ3ZTQ0NTRmOGY0YzlhYmE2MjdmM2MzNzVhIn0.Dgy7_vLBxuhRy-w28p3TzF09boZRvSD7sNwCiMkKBk6RtXuMlSh9xRGPL3CjWLxORd8lYp_ykqV8_Uj9ima_2XzViJgX1UrKXGLXWTxCbPlWs6ONJHmT8MWjd6jbzPInU55Sb75PAAFPq99ZPKzcLTPUk33CJCJbX1dOGvKgETI\""
+    "environ['HBP_AUTH_TOKEN'] = token"
    ]
   },
   {

--- a/siibra/atlas.py
+++ b/siibra/atlas.py
@@ -312,9 +312,9 @@ class Atlas:
 
         for cls in features.extractor_types[modality]:
             if modality=='GeneExpression':
-                extractor = cls(kwargs['gene'])
+                extractor = cls(self,kwargs['gene'])
             else:
-                extractor = cls()
+                extractor = cls(self)
             hits.extend(extractor.pick_selection(self))
 
         return hits

--- a/siibra/ebrains.py
+++ b/siibra/ebrains.py
@@ -46,10 +46,10 @@ def execute_query_by_id(org, domain, schema, version, query_id, params={}):
     url = "https://kg.humanbrainproject.eu/query/{}/{}/{}/{}/{}/instances?databaseScope=RELEASED".format(
         org, domain, schema, version, query_id )
     r = cached_get( url, headers={
-            'Content-Type':'application/json',
-            'Authorization': 'Bearer {}'.format(authentication.get_token())
-            }, 
-            msg_if_not_cached="No cached data. Will now run EBRAINS KG query. This may take a while...",
-           params=params)
+        'Content-Type':'application/json',
+        'Authorization': 'Bearer {}'.format(authentication.get_token())
+        }, 
+        msg_if_not_cached="No cached data. Will now run EBRAINS KG query. This may take a while...",
+        params=params)
     return json.loads(r)
 

--- a/siibra/features/extractor.py
+++ b/siibra/features/extractor.py
@@ -24,8 +24,10 @@ class FeatureExtractor(ABC):
 
     _FEATURETYPE = Feature
 
-    def __init__(self):
+    def __init__(self,atlas):
         self.features = []
+        self.parcellation = atlas.selected_parcellation
+        self.region = atlas.selected_region
 
     def pick_selection(self,atlas):
         """

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -14,6 +14,7 @@
 
 from abc import ABC,abstractmethod
 from .. import logger
+from ..region import Region
 
 class Feature(ABC):
     """ 
@@ -62,7 +63,8 @@ class RegionalFeature(Feature):
     TODO store region as an object that has a link to the parcellation
     """
 
-    def __init__(self,region):
+    def __init__(self,region : Region):
+        assert(isinstance(region,Region))
         self.region = region
  
     def matches(self,atlas):
@@ -70,9 +72,9 @@ class RegionalFeature(Feature):
         Returns true if this feature is linked to the currently selected region
         in the atlas.
         """
-        matching_regions = atlas.selected_region.find(self.region)
-        for region in matching_regions:
-            if atlas.region_selected(region):
+        for r in self.region:
+            matching_regions = atlas.selected_region.find(r)
+            if len(matching_regions)>0:
                 return True
 
 class GlobalFeature(Feature):

--- a/siibra/features/genes.py
+++ b/siibra/features/genes.py
@@ -123,14 +123,14 @@ https://alleninstitute.org/legal/terms-use/."""
     with open(genename_file,'r') as f:
         GENE_NAMES = json.load(f)
 
-    def __init__(self,gene):
+    def __init__(self,atlas,gene):
         """
         Retrieves probes IDs for the given gene, then collects the
         Microarray probes, samples and z-scores for each donor.
         TODO check that this is only called for ICBM space
         """
 
-        FeatureExtractor.__init__(self)
+        FeatureExtractor.__init__(self,atlas)
         self.gene = gene
 
         if not self.__class__._notification_shown:

--- a/siibra/region.py
+++ b/siibra/region.py
@@ -136,7 +136,7 @@ class Region(anytree.NodeMixin):
 
     def find(self,regionspec,select_uppermost=False,mapindex=None):
         """
-        Find region that match the given region specification in the subtree
+        Find regions that match the given region specification in the subtree
         headed by this region. 
 
         Parameters
@@ -176,6 +176,7 @@ class Region(anytree.NodeMixin):
         else:
             return list(result)
 
+    @cached
     def matches(self,regionspec,mapindex=None):
         """ 
         Checks wether this region matches the given region specification. 
@@ -210,11 +211,13 @@ class Region(anytree.NodeMixin):
                 return all([self.labelindex==regionspec])
         elif isinstance(regionspec,str):
             # string is given, perform some lazy string matching
+            words = splitstr(self.name.lower())
             return any([
-                    all([w.lower() in splitstr(self.name.lower()) 
-                        for w in splitstr(regionspec)]),
                     regionspec==self.key,
-                    regionspec==self.name ])
+                    regionspec==self.name,
+                    all([w.lower() in words 
+                        for w in splitstr(regionspec)])
+                    ])
         else:
             raise TypeError(
                     "Cannot interpret region specification of type '{}'".format(

--- a/siibra/retrieval.py
+++ b/siibra/retrieval.py
@@ -174,6 +174,7 @@ def cached_get(url,msg_if_not_cached=None,**kwargs):
     cache, otherwise returns the result from the cache.
     This leaves the interpretation of the returned content to the caller.
     TODO we might extend this as a general tool for the siibra library, and make it a decorator
+    TODO this hashes the authentication token as part of kwargs, which might not be desired
     """
     url_hash = hashlib.sha256((url+json.dumps(kwargs)).encode('ascii')).hexdigest()
     cachefile_content = os.path.join(CACHEDIR,url_hash)+".content"

--- a/test/test_atlas.py
+++ b/test/test_atlas.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from siibra.atlas import REGISTRY
-from siibra import atlas
+from siibra import atlas,parcellations,modalities
 from test.get_token import get_token
 
 token = get_token()
@@ -116,6 +116,14 @@ class TestAtlas(unittest.TestCase):
         # wrong modality, no region selected
         # GeneExpression
         pass
+
+    def test_get_features_connectivity_profile_filter_by_sel_parc(self):
+        
+        expected_p_id='minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-25'
+        self.atlas.select_parcellation(parcellations[expected_p_id])
+        self.atlas.select_region('hoc1 left')
+        conns=self.atlas.get_features(modalities.ConnectivityProfile)
+        assert(all([conn.parcellation.id == expected_p_id for conn in conns]))
 
     def test_regionsprops(self):
         pass

--- a/test/test_extract_transmitter_receptor_densities.py
+++ b/test/test_extract_transmitter_receptor_densities.py
@@ -16,14 +16,15 @@ class TestExtractTransmitterReceptorDensities(unittest.TestCase):
         atlas.select_parcellation(sb.parcellations.JULICH_BRAIN_CYTOARCHITECTONIC_MAPS_2_5)
         atlas.select_region(atlas.regionnames.AREA_HOC1_V1_17_CALCS_LEFT_HEMISPHERE)
         features = atlas.get_features(modalities.ReceptorDistribution)
+        print(features)
         self.assertTrue(len(features) == 1)
         self.assertEqual(features[0].name, 'Density measurements of different receptors for Area hOc1 (V1, 17, CalcS) [human, v1.0]')
 
         regions = ['hOc1', 'hOc2', 'IFG']
-        query = sb.features.receptors.ReceptorQuery()
-        self.assertTrue(len(query.features) >= 69)
+        query = sb.features.receptors.ReceptorQuery(atlas)
+        self.assertTrue(len(query.features) >= 42)
         for q in regions:
-            matched_features = [r.region for r in query.features if q in r.region]
+            matched_features = [f for f in query.features if f.region.matches(q)]
             self.assertGreater(len(matched_features),0)
 
 


### PR DESCRIPTION
RegionFeatures now require a concrete Region object at construction time, not only any region specification like an possibly incomplete region name. As a consequence, FeatureExtractors take an atlas object now in their constructor. This moves  region decoding to the Feature Extraction stage for example for ConnectivityProfile features, make the extraction a bit slower, but downstream feature queries safer.  