### PR TITLE
support rodent atlases

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,6 +4,8 @@ on: [ 'push' ]
 jobs:
   check-importable:
     runs-on: ubuntu-latest
+    env:
+      SIIBRA_CONFIG_GITLAB_PROJECT_TAG: develop # test against develop branch of config
     strategy:
       fail-fast: false
       matrix:
@@ -21,4 +23,4 @@ jobs:
     
     - name: cd to / and try to import
       run: |
-        cd / && SIIBRA_CONFIG_GITLAB_PROJECT_TAG=master python -c 'import siibra'
+        cd / && python -c 'import siibra'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.7', '3.6' ]
+        python-version: [ '3.8', '3.7' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -21,4 +21,4 @@ jobs:
     
     - name: cd to / and try to import
       run: |
-        cd / && python -c 'import siibra'
+        cd / && SIIBRA_CONFIG_GITLAB_PROJECT_TAG=master python -c 'import siibra'

--- a/.github/workflows/siibra-testing.yml
+++ b/.github/workflows/siibra-testing.yml
@@ -10,6 +10,7 @@ jobs:
       JUGEX_CLIENT_SECRET: ${{ secrets.JUGEX_CLIENT_SECRET }}
       HBP_OIDC_ENDPOINT: ${{ secrets.HBP_OIDC_ENDPOINT }}
       CI_PIPELINE: ${{ secrets.CI_PIPELINE }}
+      SIIBRA_CONFIG_GITLAB_PROJECT_TAG: master # test against master branch of config
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/siibra-testing.yml
+++ b/.github/workflows/siibra-testing.yml
@@ -10,7 +10,7 @@ jobs:
       JUGEX_CLIENT_SECRET: ${{ secrets.JUGEX_CLIENT_SECRET }}
       HBP_OIDC_ENDPOINT: ${{ secrets.HBP_OIDC_ENDPOINT }}
       CI_PIPELINE: ${{ secrets.CI_PIPELINE }}
-      SIIBRA_CONFIG_GITLAB_PROJECT_TAG: master # test against master branch of config
+      SIIBRA_CONFIG_GITLAB_PROJECT_TAG: develop # test against develop branch of config
     strategy:
       fail-fast: false
       matrix:

--- a/siibra/atlas.py
+++ b/siibra/atlas.py
@@ -58,8 +58,10 @@ class Atlas:
         Provides an object hook for the json library to construct an Atlas
         object from a json stream.
         """
-        if all([ '@id' in obj, 'spaces' in obj, 'parcellations' in obj,
-            obj['@id'].startswith("juelich/iav/atlas/v1.0.0") ]):
+        if obj.get('@type') != TYPE_STRING:
+            return obj
+
+        if all([ '@id' in obj, 'spaces' in obj, 'parcellations' in obj ]):
             p = Atlas(obj['@id'], obj['name'])
             for space_id in obj['spaces']:
                 assert(space_id in spaces)
@@ -341,7 +343,7 @@ class Atlas:
         smap = self.selected_parcellation.get_map( space, regional=True, squeeze=False )
         return smap.assign_regions(xyz_phys, sigma_phys, thres_percent, print_report=True)
 
-
+TYPE_STRING='juelich/iav/atlas/v1.0.0'
 REGISTRY = ConfigurationRegistry('atlases', Atlas)
 
 if __name__ == '__main__':

--- a/siibra/config.py
+++ b/siibra/config.py
@@ -65,7 +65,7 @@ class ConfigurationRegistry:
         self.cls = cls
         config_files = [ v['name'] 
                 for v in project.repository_tree(
-                    path=config_subfolder, ref=GITLAB_PROJECT_TAG)
+                    path=config_subfolder, ref=GITLAB_PROJECT_TAG, all=True) # by default, only returning 20 items
                 if v['type']=='blob'
                 and v['name'].endswith('.json') ]
         for configfile in config_files:

--- a/siibra/config.py
+++ b/siibra/config.py
@@ -23,10 +23,12 @@ import os
 # We tag the configuration with each release
 GITLAB_SERVER = 'https://jugit.fz-juelich.de'
 GITLAB_PROJECT_ID=3484
-GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG", "siibra-{}".format(__version__))
+GITLAB_PROJECT_TAG="siibra-{}".format(__version__)
+SIIBRA_CONFIG_GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG")
 
-if "SIIBRA_CONFIG_GITLAB_PROJECT_TAG" in os.environ:
-    logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")
+if SIIBRA_CONFIG_GITLAB_PROJECT_TAG is not None and SIIBRA_CONFIG_GITLAB_PROJECT_TAG != '':
+    logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {SIIBRA_CONFIG_GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")
+    GITLAB_PROJECT_TAG=SIIBRA_CONFIG_GITLAB_PROJECT_TAG
 
 class ConfigurationRegistry:
     """

--- a/siibra/parcellation.py
+++ b/siibra/parcellation.py
@@ -199,7 +199,7 @@ class Parcellation:
         object from a json stream.
         """
         required_keys = ['@id','name','shortName','maps','regions']
-        if any([k not in obj for k in required_keys]):
+        if obj.get('@type') != TYPE_STRING or any([k not in obj for k in required_keys]):
             return obj
 
         # create the parcellation, it will create a parent region node for the regiontree.
@@ -744,4 +744,5 @@ class ParcellationMap:
 
         return assignments
 
+TYPE_STRING = 'minds/core/parcellationatlas/v1.0.0'
 REGISTRY = ConfigurationRegistry('parcellations', Parcellation)

--- a/siibra/region.py
+++ b/siibra/region.py
@@ -439,7 +439,7 @@ class Region(anytree.NodeMixin):
         # first collect any children 
         children = []
         if "children" in jsonstr:
-            for regiondef in jsonstr["children"]:
+            for regiondef in jsonstr.get("children", []) or []: # catch either: children not defined or defined, but nullish
                 children.append(Region.from_json(regiondef,parcellation))
 
         # Then setup the new region object

--- a/siibra/space.py
+++ b/siibra/space.py
@@ -72,6 +72,10 @@ class Space:
         Provides an object hook for the json library to construct an Atlas
         object from a json stream.
         """
+
+        if obj.get('@type') != TYPE_STRING:
+            return obj
+            
         required_keys = ['@id','name','shortName','templateUrl','templateType']
         if any([k not in obj for k in required_keys]):
             return obj
@@ -94,4 +98,5 @@ class Space:
                         volume_src = volume_src)
         return obj
 
+TYPE_STRING='minds/core/referencespace/v1.0.0'
 REGISTRY = ConfigurationRegistry('spaces', Space)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -7,6 +7,9 @@ import siibra
 class TestConfig1(TestCase):
 
     def test_exported_variable(self):
+        os.environ['SIIBRA_CONFIG_GITLAB_PROJECT_TAG'] = ''
+        importlib.reload(siibra)
+        importlib.reload(siibra.config)
         self.assertEqual(
             siibra.config.GITLAB_PROJECT_TAG,
             f"siibra-{siibra.__version__}"

--- a/test/test_space.py
+++ b/test/test_space.py
@@ -15,6 +15,7 @@ class TestSpaces(unittest.TestCase):
 
     json_space_with_zip = {
         '@id': 'space1/minds/core/referencespace/v1.0.0',
+        '@type': 'minds/core/referencespace/v1.0.0',
         'name': name,
         'shortName': name,
         'templateUrl': url,
@@ -24,6 +25,7 @@ class TestSpaces(unittest.TestCase):
 
     json_space_without_zip = {
         '@id': 'space1/minds/core/referencespace/v1.0.0',
+        '@type': 'minds/core/referencespace/v1.0.0',
         'name': name,
         'shortName': name,
         'templateUrl': url,


### PR DESCRIPTION
This PR relies on https://jugit.fz-juelich.de/t.dickscheid/brainscapes-configurations/-/merge_requests/4 being merged.

Linked PR introduces explicit type checking (`@type` field) for atlas, space and parcellations. This will likely be less buggy, as `@id` is not a good indication of types

fixes #35 