### PR TITLE
Feature use volume src

### DIFF
--- a/examples/Different species.ipynb
+++ b/examples/Different species.ipynb
@@ -1,0 +1,125 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ\n",
+    "from nilearn import plotting\n",
+    "import numpy as np\n",
+    "#environ['SIIBRA_CONFIG_GITLAB_PROJECT_TAG']=\"develop\"\n",
+    "import siibra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Allen mouse brain atlas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atlas = siibra.atlases.ALLEN_MOUSE_COMMON_COORDINATE_FRAMEWORK_V3\n",
+    "mousetpl = atlas.get_template()\n",
+    "parcellationmap = atlas.get_map()\n",
+    "for img in parcellationmap:\n",
+    "    plotting.plot_roi(img,bg_img=mousetpl,vmax=10000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Waxholm space atlas of the sprague dawley rat brain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atlas = siibra.atlases.WAXHOLM_SPACE_ATLAS_OF_THE_SPRAGUE_DAWLEY_RAT_BRAIN\n",
+    "waxholm = atlas.get_template()\n",
+    "parcellationmap = atlas.get_map()\n",
+    "for img in parcellationmap:\n",
+    "    plotting.plot_roi(img,bg_img=waxholm,cmap=\"Set1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Human brain atlas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MNI space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atlas = siibra.atlases.MULTILEVEL_HUMAN_ATLAS\n",
+    "mni152 = atlas.get_template()\n",
+    "parcellationmap = atlas.get_map(siibra.spaces.MNI152_2009C_NONL_ASYM)\n",
+    "for img in parcellationmap:\n",
+    "    plotting.plot_roi(img,bg_img=mni152,cut_coords=[0,0,0],cmap='Set1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BigBrain space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reso = 640\n",
+    "bigbrain = atlas.get_template(siibra.spaces.BIG_BRAIN,resolution=reso)\n",
+    "parcellationmap = atlas.get_map(siibra.spaces.BIG_BRAIN, resolution=reso)\n",
+    "for img in parcellationmap:\n",
+    "    plotting.plot_roi(img,bg_img=bigbrain,cut_coords=[0,0,0],cmap='Set1')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -23,6 +23,8 @@ ch.setFormatter(formatter)
 logger.addHandler(ch)
 logger.setLevel("INFO")
 
+logger.info(f"Version: {__version__}")
+
 # read in the package version from file
 from os import path
 
@@ -32,4 +34,3 @@ from .atlas import REGISTRY as atlases
 from .retrieval import clear_cache
 from .features import modalities
 
-logger.info("Version: "+__version__)

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # __version__ is parsed by setup.py
-__version__='0.0.9.dev4'
+__version__='0.1a1'
 
 import logging
 logger = logging.getLogger(__name__)

--- a/siibra/atlas.py
+++ b/siibra/atlas.py
@@ -102,9 +102,9 @@ class Atlas:
             raise Exception('Invalid Parcellation')
         self.selected_parcellation = parcellation_obj
         self.selected_region = parcellation_obj.regiontree
-        logger.info('Selected parcellation "{}"'.format(self.selected_parcellation))
+        logger.info(f'{str(self)}: Selected parcellation "{format(self.selected_parcellation)}"')
 
-    def get_map(self, space : Space, resolution=None):
+    def get_map(self, space=None, resolution=None):
         """
         return the map provided by the selected parcellation in the given space.
         This just forwards to the selected parcellation object, see
@@ -133,7 +133,7 @@ class Atlas:
         """
         return self.selected_region.build_mask( space, resolution=resolution )
 
-    def get_template(self, space, resolution=None ):
+    def get_template(self, space=None, resolution=None ):
         """
         Get the volumetric reference template image for the given space.
 
@@ -155,9 +155,16 @@ class Atlas:
         A nibabel Nifti object representing the reference template, or None if not available.
         TODO Returning None is not ideal, requires to implement a test on the other side. 
         """
+        if space is None:
+            space = self.spaces[0]
+            if len(self.spaces)>1:
+                logger.warning(f'{self.name} supports multiple spaces, but none was specified. Falling back to {space.name}.')
+
         if space not in self.spaces:
-            logger.error('The selected atlas does not support the requested reference space.')
-            logger.error('- Atlas: {}'.format(self.name))
+            logger.error(f'Atlas "{self.name}" does not support reference space "{space.name}" (id {space.id}).')
+            print("Available spaces:")
+            for space in self.spaces:
+                print(space.name,space.id)
             return None
 
         return space.get_template(resolution)

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from enum import Enum
 
 class Glossary:
     """
@@ -50,4 +51,8 @@ def create_key(name):
             "".join([e if e.isalnum() else " " 
                 for e in name]).upper().strip() 
             )
+
+class MapType(Enum):
+    LABELLED = 1
+    CONTINUOUS = 2
 

--- a/siibra/config.py
+++ b/siibra/config.py
@@ -25,9 +25,7 @@ GITLAB_SERVER = 'https://jugit.fz-juelich.de'
 GITLAB_PROJECT_ID=3484
 GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG", "siibra-{}".format(__version__))
 
-logger.info(f"Using configuration tag {GITLAB_PROJECT_TAG}")
-#if "SIIBRA_CONFIG_GITLAB_PROJECT_TAG" in os.environ:
-    #logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")
+logger.info(f"Configuration: {GITLAB_PROJECT_TAG}")
 
 class ConfigurationRegistry:
     """

--- a/siibra/config.py
+++ b/siibra/config.py
@@ -25,8 +25,9 @@ GITLAB_SERVER = 'https://jugit.fz-juelich.de'
 GITLAB_PROJECT_ID=3484
 GITLAB_PROJECT_TAG=os.getenv("SIIBRA_CONFIG_GITLAB_PROJECT_TAG", "siibra-{}".format(__version__))
 
-if "SIIBRA_CONFIG_GITLAB_PROJECT_TAG" in os.environ:
-    logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")
+logger.info(f"Using configuration tag {GITLAB_PROJECT_TAG}")
+#if "SIIBRA_CONFIG_GITLAB_PROJECT_TAG" in os.environ:
+    #logger.warning(f"environ SIIBRA_CONFIG_GITLAB_PROJECT_TAG set, using {GITLAB_PROJECT_TAG} as GITLAB_PROJECT_TAG")
 
 class ConfigurationRegistry:
     """

--- a/siibra/neuroglancer.py
+++ b/siibra/neuroglancer.py
@@ -33,14 +33,13 @@ def is_ngprecomputed(url):
     except Exception as _:
         return False
 
-
 @cached
 def load_ngprecomputed(url,resolution):
     """
     Shortcut for loading data from a neuroglancer precomputed volume directly
     into a spatial image object
     """
-    V = BigBrainVolume(url)
+    V = NgVolume(url)
     return V.build_image(resolution,clip=True)
 
 def bbox3d(A):
@@ -59,27 +58,28 @@ def bbox3d(A):
     ])
 
 
-class BigBrainVolume:
+class NgVolume:
     """
     TODO use siibra requests cache
-    
     """
     # function to switch x/y coordinates on a vector or matrix.
     # Note that direction doesn't matter here since the inverse is the same.
     switch_xy = lambda X : np.dot(np.identity(4)[[1,0,2,3],:],X) 
 
     # Gigabyte size that is considered feasible for ad-hoc downloads of
-    # BigBrain data. This is used to avoid accidental huge downloads.
+    # neuroglancer volume data. This is used to avoid accidental huge downloads.
     gbyte_feasible = 0.5
     
-    def __init__(self,ngsite,fill_missing=True):
+    def __init__(self,ngsite,transform_phys=np.identity(4),fill_missing=True):
         """
         ngsite: base url of neuroglancer http location
+        transform_phys: transform to be applied after scaling voxels to nm
         """
-        with requests.get(ngsite+'/transform.json') as r:
-            self._translation_nm = np.array(json.loads(r.content))[:,-1]
+        #with requests.get(ngsite+'/transform.json') as r:
+            #self._translation_nm = np.array(json.loads(r.content))[:,-1]
         with requests.get(ngsite+'/info') as r:
             self.info = json.loads(r.content)
+        self.transform_phys = transform_phys
         self.volume = CloudVolume(ngsite,fill_missing=fill_missing,progress=False)
         self.ngsite = ngsite
         self.nbits = np.iinfo(self.volume.info['data_type']).bits
@@ -92,6 +92,7 @@ class BigBrainVolume:
                 for i,v in enumerate(self.volume.scales) }
         self.helptext = "\n".join(["{:7.0f} micron {:10.4f} GByte".format(k,v['GBytes']) 
             for k,v in self.resolutions_available.items()])
+        logger.debug(f"Available resolutions for volume:\n {self.helptext}")
 
     def largest_feasible_resolution(self):
         # returns the highest resolution in micrometer that is available and
@@ -112,27 +113,26 @@ class BigBrainVolume:
             If Bbox, clip by this bounding box
         """
 
-        # correct clipping offset, if needed
+        # possible clipping offset in voxel space
         voxelshift = np.identity(4)
         if (type(clip)==bool) and clip is True:
             voxelshift[:3,-1] = self._clipcoords(mip)[:3,0]
         elif isinstance(clip,Bbox):
             voxelshift[:3,-1] = clip.minpt
 
-        # retrieve the pixel resolution
+        # the scaling matrix from voxel to nm
         resolution_nm = self.info['scales'][mip]['resolution']
-
-        # build affine matrix in nm physical space
-        affine = np.identity(4)
+        scaling = np.identity(4)
         for i in range(3):
-            affine[i,i] = resolution_nm[i]
-            affine[i,-1] = self._translation_nm[i]
+            scaling[i,i] = resolution_nm[i]
+
+        affine = np.dot(self.transform_phys,scaling)
             
         # warp from nm to mm   
         affine[:3,:]/=1000000.
     
         return np.dot(affine,voxelshift)
-        #return BigBrainVolume.switch_xy(np.dot(affine,voxelshift))
+        #return NgVolume.switch_xy(np.dot(affine,voxelshift))
 
     def _clipcoords(self,mip):
         # compute clip coordinates in voxels for the given mip 
@@ -174,7 +174,7 @@ class BigBrainVolume:
         else:
             bbox = Bbox([0, 0, 0],self.volume.mip_shape(mip))
         gbytes = bbox.volume()*self.nbits/(8*1024**3)
-        if not force and gbytes>BigBrainVolume.gbyte_feasible:
+        if not force and gbytes>NgVolume.gbyte_feasible:
             # TODO would better do an estimate of the acutal data size
             logger.error("Data request is too large (would result in an ~{:.2f} GByte download, the limit is {}).".format(gbytes,self.gbyte_feasible))
             print(self.helptext)
@@ -193,15 +193,17 @@ class BigBrainVolume:
         # be used to move on.
         if resolution is None:
             maxres = self.largest_feasible_resolution()
-            logger.info('Using the largest feasible resolution of {} micron'.format(maxres))
-            return self.resolutions_available[maxres]['mip']
-        elif resolution in self.resolutions_available.keys(): 
-            return self.resolutions_available[resolution]['mip']
-        logger.error('The requested resolution ({} micron) is not available. Choose one of:'.format(resolution))
-        print(self.helptext)
-        return None
+            mip = self.resolutions_available[maxres]['mip']
+            logger.info(f'Using largest feasible resolution of {maxres} micron (mip={mip})')
+        elif resolution in self.resolutions_available:
+            mip = self.resolutions_available[resolution]['mip']
+        else:
+            logger.error(f'Requested resolution of {resolution} micron not available.')
+            print(self.helptext)
+            mip = None
+        return mip
         
-    def build_image(self,resolution,clip=True,transform=lambda I: I, force=False):
+    def build_image(self,resolution=None,clip=True,transform=lambda I: I, force=False):
         """
         Compute and return a spatial image for the given mip.
         
@@ -216,8 +218,8 @@ class BigBrainVolume:
             threshold set in the gbytes_feasible member variable.
         """
         mip = self.determine_mip(resolution)
-        if not mip:
-            raise ValueError("Invalid image resolution for this neuroglancer precomputed tile source.")
+        if mip is None:
+            raise ValueError(f"Invalid image resolution '{resolution}' for this tile source.")
         return nib.Nifti1Image(
             transform(self._load_data(mip,clip,force)),
             affine=self.affine(mip,clip)

--- a/siibra/neuroglancer.py
+++ b/siibra/neuroglancer.py
@@ -75,11 +75,11 @@ class NgVolume:
         ngsite: base url of neuroglancer http location
         transform_phys: transform to be applied after scaling voxels to nm
         """
+        self.transform_phys = transform_phys
         #with requests.get(ngsite+'/transform.json') as r:
-            #self._translation_nm = np.array(json.loads(r.content))[:,-1]
+            #transform_phys_onsite = np.array(json.loads(r.content))
         with requests.get(ngsite+'/info') as r:
             self.info = json.loads(r.content)
-        self.transform_phys = transform_phys
         self.volume = CloudVolume(ngsite,fill_missing=fill_missing,progress=False)
         self.ngsite = ngsite
         self.nbits = np.iinfo(self.volume.info['data_type']).bits

--- a/siibra/parcellation.py
+++ b/siibra/parcellation.py
@@ -481,11 +481,13 @@ class ParcellationMap:
             regions = [r for r in self.parcellation.regiontree 
                     if r.has_regional_map(self.space,MapType.LABELLED)]
 
-            for region in regions:
+            msg =f"Loading {len(regions)} regional maps for space '{self.space.name}'..."
+            logger.info(msg)
+            for region in tqdm(regions,total=len(regions)):
                 assert(region.labelindex)
 
                 # load region mask
-                mask_ = self._load_regional_map(region,MapType.LABELLED)
+                mask_ = self._load_regional_map(region,MapType.LABELLED,quiet=True)
                 if not mask_:
                     continue
                 if mask_.dataobj.dtype.kind!='u':

--- a/siibra/parcellation.py
+++ b/siibra/parcellation.py
@@ -399,7 +399,6 @@ class ParcellationMap:
         self.parcellation = parcellation
         self.space = space
         self.resolution = resolution
-        print("parcellation volume with resolution",resolution)
 
         # check for available maps per region
         self.maploaders = []
@@ -416,6 +415,7 @@ class ParcellationMap:
                     if url:
                         self.maploaders.append(lambda q=False,u=url: self._load_parcellation_map(u,quiet=q))
                         regionmap = self.maploaders[-1]()
+                        unmatched_labels = []
                         for labelindex in np.unique(np.asarray(regionmap.dataobj)):
                             if labelindex==0:
                                 continue # this is the background only
@@ -424,7 +424,9 @@ class ParcellationMap:
                                 if labelindex>0:
                                     self.regions[labelindex,mapindex] = region
                             except ValueError:
-                                logger.error(f'Labelindex {labelindex} could not be decoded by {self.parcellation.name}')
+                                unmatched_labels.append(labelindex)
+                        if unmatched_labels:
+                            logger.warning(f"{len(unmatched_labels)} labels in labelled volume couldn't be matched to region definitions in {self.parcellation.name}: {unmatched_labels}")
 
         elif maptype==ParcellationMap.MapType.REGIONAL_MAPS:
             regions = [r for r in parcellation.regiontree if r.has_regional_map(space)]

--- a/siibra/parcellation.py
+++ b/siibra/parcellation.py
@@ -156,7 +156,7 @@ class Parcellation:
             if len(self.volume_src)>1:
                 logger.warning(f'Parcellation "{str(self)}" provides maps in multiple spaces. Using the first, "{str(space)}"')
 
-        if not self.supports_space(self):
+        if not self.supports_space(space):
             raise ValueError('Parcellation "{}" does not provide a map for space "{}"'.format(
                 str(self), str(space) ))
 
@@ -171,7 +171,7 @@ class Parcellation:
     def names(self):
         return self.regiontree.names
 
-    def supports_space(self,space):
+    def supports_space(self,space : Space):
         """
         Return true if this parcellation supports the given space, else False.
         """

--- a/siibra/region.py
+++ b/siibra/region.py
@@ -439,11 +439,13 @@ class Region(anytree.NodeMixin):
         if 'volumeSrc' in jsonstr:
             for space_id,space_vsources in jsonstr['volumeSrc'].items():
                 space = spaces[space_id]
-                vsrc_definitions = [vsrc|{'key':key} 
+                vsrc_definitions = [{**vsrc,**{'key':key}}
                         for key,vsources in space_vsources.items()
                         for vsrc in vsources ]
                 if len(vsrc_definitions)>1:
                     raise NotImplementedError(f"Multiple volume sources defined for region {name} and space {space_id}. This is not yet supported by siibra.")
+                if len(vsrc_definitions)==0 or vsrc_definitions[0] is None:
+                    raise ValueError(f"No valid volume source found!")
                 vsrc = VolumeSrc.from_json(vsrc_definitions[0])
                 key = vsrc_definitions[0]['key']
                 if key not in key2maptype:

--- a/siibra/volume_src.py
+++ b/siibra/volume_src.py
@@ -12,14 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import logger
+import numpy as np
+from .retrieval import download_file
+from .neuroglancer import NgVolume
+import nibabel as nib
+
+from os import environ
+import json
+
 class VolumeSrc:
 
-    def __init__(self, identifier, name, volume_type, url, detail=None):
+    def __init__(self, identifier, name, volume_type, url, detail=None, zipped_file=None, usage_type=None):
+        """
+        Construct a new volume source.
+
+        Parameters
+        ----------
+        identifier : str
+            A unique identifier for the source
+        name : str
+            A human-readable name
+        volume_type : str
+            Type of volume source, clarifying the data format. Typical names: "nii", "neuroglancer/precomputed".
+            TODO create a fixed list (enum?) of supported types, or better: derive types from VolumeSrc object
+        usage_type : str
+            Indicates the use of the volume src, for example "pmap", "collect"
+            TODO Find a clearer way of modeling this.
+        url : str
+            The URL to the volume src, typically a url to the corresponding image or tilesource.
+        detail : dict
+            Detailed information. Currently only used to store a transformation matrix  for neuroglancer tilesources.
+        zipped_file : str
+            The filename to be extracted from a zip file. If given, the url is
+            expected to point to a downloadable zip archive. Currently used to
+            extreact niftis from zip archives, as for example in case of the
+            MNI reference templates.
+        """
         self.id = identifier
         self.name = name
         self.url = url
+        if 'SIIBRA_URL_MODS' in environ and url:
+            mods = json.loads(environ['SIIBRA_URL_MODS'])
+            for old,new in mods.items():
+                self.url.replace(old,new)
+            if self.url!=url:
+                logger.warning(f'Applied URL modification! "{mods}"') 
+                logger.info(f'Old URL: {url}')
+                logger.info(f'New URL: {self.url}')
         self.volume_type = volume_type
-        self.detail=detail
+        self.usage_type = usage_type
+        self.detail = detail
+        self.zipped_file = zipped_file
+        self.space = None
 
     def __str__(self):
         return f'{self.volume_type} {self.url}'
@@ -27,16 +72,43 @@ class VolumeSrc:
     def get_url(self):
         return self.url
 
+    def fetch(self,resolution=None):
+        """
+        Loads and returns a Nifti1Image object representing the template space.
+        """
+        if self.volume_type=='nii':
+            filename = download_file(self.url,ziptarget=self.zipped_file)
+            if filename:
+                return nib.load(filename)
+            else:
+                return None
+
+        elif self.volume_type=='neuroglancer/precomputed':
+            try:
+                transform = np.array(self.detail['neuroglancer/precomputed']['transform'])
+            except AttributeError:
+                logger.warning('No transform provided by neuroglancer volume source.')
+                transform = np.identity(4)
+            volume = NgVolume(self.url,transform_phys=transform)
+            return volume.build_image(resolution)
+
+        else:
+            logger.error(f'Cannot fetch a volume for type "{self.volume_type}".')
+            return None
+
     @staticmethod
     def from_json(obj):
         """
-        Provides an object hook for the json library to construct an Atlas
+        Provides an object hook for the json library to construct a VolumeSrc
         object from a json stream.
         """
         if "@type" in obj and obj['@type'] == "fzj/tmp/volume_type/v0.0.1":
             return VolumeSrc(obj['@id'], obj['name'],
                     volume_type=obj['volume_type'],
                     url=obj['url'],
-                    detail=obj.get('detail'))
+                    detail=obj.get('detail'),
+                    zipped_file=obj.get('zipped_file'),
+                    usage_type=obj.get('usage_type')
+                    )
         
         return obj

--- a/siibra/volume_src.py
+++ b/siibra/volume_src.py
@@ -55,11 +55,11 @@ class VolumeSrc:
         if 'SIIBRA_URL_MODS' in environ and url:
             mods = json.loads(environ['SIIBRA_URL_MODS'])
             for old,new in mods.items():
-                self.url.replace(old,new)
+                self.url = self.url.replace(old,new)
             if self.url!=url:
-                logger.warning(f'Applied URL modification! "{mods}"') 
-                logger.info(f'Old URL: {url}')
-                logger.info(f'New URL: {self.url}')
+                logger.warning(f'Applied URL modification:') 
+                print(f' - Old URL: {url}')
+                print(f' - New URL: {self.url}')
         self.volume_type = volume_type
         self.usage_type = usage_type
         self.detail = detail

--- a/test/test_region.py
+++ b/test/test_region.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from siibra import parcellations, ebrains, spaces, retrieval
 from siibra.region import Region
+from siibra.commons import MapType
 
 
 class TestRegions(unittest.TestCase):
@@ -22,7 +23,20 @@ class TestRegions(unittest.TestCase):
             'kgId': kg_id,
             'kgSchema': 'minds/core/dataset/v1.0.0',
             'filename': 'Interposed Nucleus (Cerebellum) [v6.2, ICBM 2009c Asymmetric, left hemisphere]'
-        }]
+        }],
+        "volumeSrc": {
+            spaces[0].id : {
+                "pmap": [
+                    {
+                        "@type": "fzj/tmp/volume_type/v0.0.1",
+                        "@id": "fzj/tmp/volume_type/v0.0.1/pmap",
+                        'name': 'Probabilistic map '+region_name,
+                        "volume_type": "nii",
+                        "url": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-Ch-4_pub/4.2/Ch-4_l_N10_nlin2Stdcolin27_4.2_publicP_b92bf6270f6426059d719a6ff4d46aa7.nii.gz"
+                    }
+                ]
+            },
+        }
     }
 
     parent_definition = {
@@ -36,7 +50,8 @@ class TestRegions(unittest.TestCase):
             'kgId': kg_id,
             'kgSchema': 'minds/core/dataset/v1.0.0',
             'filename': 'Interposed Nucleus (Cerebellum) [v6.2, ICBM 2009c Asymmetric, left hemisphere]'
-        }]
+        }],
+        'volumeSrc' : {}
     }
     parent_region = None
     child_region = None
@@ -53,58 +68,6 @@ class TestRegions(unittest.TestCase):
 
     def test_regions_init(self):
         self.assertEqual(str(self.child_region), self.region_name)
-
-    def test_related_ebrains_files(self):
-        ebrains.execute_query_by_id = MagicMock()
-        ebrains.execute_query_by_id.return_value = {
-            'results': [
-                {
-                    'files': ['file1', 'file2']
-                }
-            ]
-        }
-        files = self.child_region._related_ebrains_files()
-        ebrains.execute_query_by_id.assert_called_with(
-            'minds',
-            'core',
-            'dataset',
-            'v1.0.0',
-            'brainscapes_files_in_dataset',
-            params={'dataset': self.kg_id})
-
-        self.assertTrue(len(files) == 2)
-
-    def test_related_ebrains_files_with_no_origin_datasets(self):
-        ebrains.execute_query_by_id = MagicMock()
-        definition = {
-            'name': self.region_name,
-            'rgb': [170, 29, 10],
-            'labelIndex': 251,
-            'ngId': 'jubrain mni152 v18 left',
-            'children': [],
-            'position': [-9205882, -57128342, -32224599],
-        }
-        region = Region(definition, parcellations[0])
-        files = region._related_ebrains_files()
-        ebrains.execute_query_by_id.assert_not_called()
-        self.assertTrue(len(files) == 0)
-
-    def test_related_ebrains_files_with_no_kg_id(self):
-        ebrains.execute_query_by_id = MagicMock()
-        self.child_region.attrs['originDatasets'] = [{
-            'kgSchema': 'minds/core/dataset/v1.0.0',
-            'filename': 'Interposed Nucleus (Cerebellum) [v6.2, ICBM 2009c Asymmetric, left hemisphere]'
-        }]
-        files = self.child_region._related_ebrains_files()
-        ebrains.execute_query_by_id.assert_not_called()
-        self.assertTrue(len(files) == 0)
-
-    def test_related_ebrains_files_with_empty_origin_datasets(self):
-        ebrains.execute_query_by_id = MagicMock()
-        self.child_region.attrs['originDatasets'] = []
-        files = self.child_region._related_ebrains_files()
-        ebrains.execute_query_by_id.assert_not_called()
-        self.assertTrue(len(files) == 0)
 
     def test_has_no_parent(self):
         self.assertFalse(self.parent_region.has_parent(self.parentname))
@@ -146,27 +109,27 @@ class TestRegions(unittest.TestCase):
     def test_matches_with_wrong_region(self):
         self.assertFalse(self.child_region.matches(self.parent_region))
 
-    @patch('siibra.region.download_file')
+    @patch('siibra.volume_src.VolumeSrc.fetch')
     def test_regional_map_none(self, download_mock):
-        self.assertIsNone(self.parent_region.get_regional_map(spaces[0]))
+        self.assertIsNone(self.parent_region.get_regional_map(spaces[0],MapType.LABELLED))
         download_mock.assert_not_called()
 
-    @patch('siibra.region.download_file')
+    @patch('siibra.volume_src.VolumeSrc.fetch')
     def test_get_regional_map_wrong_space(self, download_mock):
         self.child_region.attrs['maps'] = {
             'spaceId': 'map_url'
         }
-        self.assertIsNone(self.child_region.get_regional_map(spaces[0]))
+        self.assertIsNone(self.child_region.get_regional_map(spaces[0],MapType.LABELLED))
         download_mock.assert_not_called()
 
-    @patch('siibra.region.download_file')
-    def test_get_regional_map_no_filename(self, download_mock):
-        download_mock.return_value = None
-        self.child_region.attrs['maps'] = {
-            spaces[0].id: spaces[0].id
-        }
-        self.assertIsNone(self.child_region.get_regional_map(spaces[0]))
-        download_mock.assert_called_with(spaces[0].id)
+    @patch('siibra.volume_src.VolumeSrc.fetch')
+    def test_get_regional_map_no_filename(self, fetch_mock):
+        fetch_mock.return_value = None
+        #self.child_region.attrs['maps'] = {
+            #spaces[0].id: spaces[0].id
+        #}
+        self.assertIsNone(self.child_region.get_regional_map(spaces[0],MapType.CONTINUOUS))
+        fetch_mock.assert_called_with(None)
 
 
 if __name__ == "__main__":

--- a/test/test_space.py
+++ b/test/test_space.py
@@ -17,18 +17,33 @@ class TestSpaces(unittest.TestCase):
         '@id': 'space1/minds/core/referencespace/v1.0.0',
         'name': name,
         'shortName': name,
-        'templateUrl': url,
-        'templateFile': ziptarget,
-        'templateType': ttype
-    }
+        'templateType': ttype,
+        "volumeSrc": [{
+            "@type": "fzj/tmp/volume_type/v0.0.1",
+            "@id": "fzj/tmp/volume_type/v0.0.1/icbm152_2009c_nonlin_asym/nifti",
+            "name": "icbm152_2009c_nonlin_asym/nifti",
+            "volume_type": ttype,
+            "url": url,
+            "zipped_file": ziptarget,
+            }]
+        }
 
     json_space_without_zip = {
         '@id': 'space1/minds/core/referencespace/v1.0.0',
         'name': name,
         'shortName': name,
         'templateUrl': url,
-        'templateType': ttype
-    }
+        'templateFile': ziptarget,
+        'templateType': ttype,
+        "volumeSrc": [{
+            "@type": "fzj/tmp/volume_type/v0.0.1",
+            "@id": "fzj/tmp/volume_type/v0.0.1/icbm152_2009c_nonlin_asym/nifti",
+            "name": "icbm152_2009c_nonlin_asym/nifti",
+            "volume_type": "nii",
+            "url": "http://www.bic.mni.mcgill.ca/~vfonov/icbm/2009/mni_icbm152_nlin_asym_09c_nifti.nii",
+            }]
+        }
+
 
     def test_space_init(self):
         space = Space(self.space_id, self.name, self.url, self.ziptarget)
@@ -40,8 +55,10 @@ class TestSpaces(unittest.TestCase):
             str(space),
             self.name
         )
+        self.assertEqual(len(space.volume_src),1)
+        vsrc = space.volume_src[0]     
         self.assertEqual(space.type,self.ttype)
-        self.assertIsNotNone(space.ziptarget)
+        self.assertEqual(vsrc.zipped_file,self.ziptarget)
 
     def test_space_from_json_without_zip(self):
         space = Space.from_json(self.json_space_without_zip)
@@ -49,7 +66,9 @@ class TestSpaces(unittest.TestCase):
             str(space),
             self.name
         )
-        self.assertIsNone(space.ziptarget)
+        self.assertEqual(len(space.volume_src),1)
+        vsrc = space.volume_src[0]     
+        self.assertIsNone(vsrc.zipped_file)
 
     def test_space_registry(self):
         spaces = REGISTRY.MULTILEVEL_HUMAN_ATLAS.spaces


### PR DESCRIPTION
This version now interprets the new volumeSrc fields in the configurations files properly, and is able to generate Waxholm and Allen Mouse atlases and display their maps, as demonstrated in the new example notebook "Different species.ipynb".

Generated version tag 0.1.a1 with a matched tag in the configurations repo.

Unit tests fixed.

Further work required to add feature queries etc. for rodent and mouse atlases, but it would make sense to merge this to develop already. 