### PR TITLE
feat: improve the response time of (ebrains) features

### DIFF
--- a/siibra/atlas.py
+++ b/siibra/atlas.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from siibra import parcellation
 from memoization import cached
 from nibabel.affines import apply_affine
 from numpy import linalg as npl
@@ -26,6 +27,16 @@ from .config import ConfigurationRegistry
 from .space import Space
 
 VERSION_BLACKLIST_WORDS=["beta","rc","alpha"]
+
+@cached
+def get_extractors(modality, **kwargs):
+    
+    if modality not in features.extractor_types.modalities:
+        logger.error("Cannot query features - no feature extractor known "\
+                "for feature type {}.".format(modality))
+        return None
+
+    return [cls(**kwargs) for cls in features.extractor_types[modality]]
 
 class Atlas:
 
@@ -331,36 +342,17 @@ class Atlas:
         M = self.build_mask(space)
         return any(check(M.slicer[:,:,:,i]) for i in range(M.shape[3])) if M.ndim==4 else check(M)
 
-    @cached
-    def __get_extractor(self, modality, **kwargs):
-        if modality not in features.extractor_types.modalities:
-            logger.error("Cannot query features - no feature extractor known "\
-                    "for feature type {}.".format(modality))
-            return None
-
-        # TODO update extractors __init__ function to accept kwargs, so this step can be drastically simplified
-        extractors = []
-        for cls in features.extractor_types[modality]:
-            if modality=='GeneExpression':
-                extractor = cls(self,kwargs['gene'])
-                extractors.append(extractor)
-            else:
-                extractor = cls(self)
-                extractors.append(extractor)
-        return extractors
-
     def get_features(self,modality,**kwargs):
         """
         Retrieve data features linked to the selected atlas configuration, by modality. 
         See siibra.features.modalities for available modalities.
         """
         hits = []
-
-        extractors = self.__get_extractor(modality, **kwargs)
-
+        extractors = get_extractors(modality,
+            parcellation=kwargs.get('parcellation', self.selected_parcellation),
+            **kwargs)
         for extractor in extractors:
             hits.extend(extractor.pick_selection(self))
-
         return hits
 
     def assign_coordinates(self,space:Space,xyz_mm,sigma_mm=3):

--- a/siibra/features/connectivity.py
+++ b/siibra/features/connectivity.py
@@ -88,9 +88,9 @@ class ConnectivityProfileExtractor(FeatureExtractor):
     _FEATURETYPE = ConnectivityProfile
     __profiles = None
 
-    def __init__(self,atlas):
+    def __init__(self,**kwargs):
 
-        FeatureExtractor.__init__(self,atlas)
+        FeatureExtractor.__init__(self,**kwargs)
         if self.__class__.__profiles is None:
             self.__load_profiles()
         for profile in self.__class__.__profiles :
@@ -163,9 +163,9 @@ class ConnectivityMatrixExtractor(FeatureExtractor):
     _FEATURETYPE = ConnectivityMatrix
     __features = None
 
-    def __init__(self,atlas):
+    def __init__(self,**kwargs):
 
-        FeatureExtractor.__init__(self,atlas)
+        FeatureExtractor.__init__(self,**kwargs)
         if self.__class__.__features is None:
             self._load_features()
         for feature in self.__class__.__features:

--- a/siibra/features/ebrainsquery.py
+++ b/siibra/features/ebrainsquery.py
@@ -96,13 +96,13 @@ class EbrainsRegionalDataset(RegionalFeature):
     def __str__(self):
         return self.name
 
-def dataset_to_feature(dataset, parcellation):
+def dataset_to_feature(reg, dataset, parcellation):
     ds_id = dataset.get('@id')
     ds_name = dataset.get('name')
     if not "dataset" in ds_id:
         logger.debug(f"'{ds_name}' is not an interpretable dataset and will be skipped.\n(id:{ds_id})")
         return None
-    regionname = r.get('name', None)
+    regionname = reg.get('name', None)
     try:
         region = parcellation.decode_region(regionname)
     except ValueError as e:
@@ -138,7 +138,7 @@ class EbrainsRegionalFeatureExtractor(FeatureExtractor):
             logger.debug(f"Retrieved ebrain results via HTTP")
 
         results = result.get('results', []) 
-        features=[dataset_to_feature(r, parcellation=self.parcellation) for r in results]
+        features=[dataset_to_feature(r, ds, parcellation=self.parcellation) for r in results for ds in r.get('datasets', [])]
         filtered_features=[f for f in features if f is not None]
         self.register_many(filtered_features)
 

--- a/siibra/features/extractor.py
+++ b/siibra/features/extractor.py
@@ -25,10 +25,10 @@ class FeatureExtractor(ABC):
 
     _FEATURETYPE = Feature
 
-    def __init__(self,atlas):
+    def __init__(self,**kwargs):
         self.features = []
-        self.parcellation = atlas.selected_parcellation
-        self.region = atlas.selected_region
+        self.parcellation = kwargs.get('parcellation')
+        self.region = kwargs.get('region')
 
     @cached
     def pick_selection(self,atlas):
@@ -48,6 +48,11 @@ class FeatureExtractor(ABC):
     def register(self,feature):
         assert(isinstance(feature,self._FEATURETYPE))
         self.features.append(feature)
+    
+    def register_many(self, features):
+        assert(isinstance(features,list))
+        assert(all([isinstance(f, self._FEATURETYPE) for f in features ]))
+        self.features.extend(features)
 
 
 class FeatureExtractorRegistry:

--- a/siibra/features/genes.py
+++ b/siibra/features/genes.py
@@ -123,14 +123,15 @@ https://alleninstitute.org/legal/terms-use/."""
     with open(genename_file,'r') as f:
         GENE_NAMES = json.load(f)
 
-    def __init__(self,atlas,gene):
+    def __init__(self,**kwargs):
         """
         Retrieves probes IDs for the given gene, then collects the
         Microarray probes, samples and z-scores for each donor.
         TODO check that this is only called for ICBM space
         """
 
-        FeatureExtractor.__init__(self,atlas)
+        FeatureExtractor.__init__(self,**kwargs)
+        gene=kwargs.get('gene')
         self.gene = gene
 
         if not self.__class__._notification_shown:
@@ -223,4 +224,4 @@ https://alleninstitute.org/legal/terms-use/."""
 
 if __name__ == "__main__":
 
-    featureextractor = AllenBrainAtlasQuery('GABARAPL2')
+    featureextractor = AllenBrainAtlasQuery(gene='GABARAPL2')

--- a/siibra/features/receptors.py
+++ b/siibra/features/receptors.py
@@ -512,7 +512,7 @@ class ReceptorQuery(FeatureExtractor):
         FeatureExtractor.__init__(self,**kwargs)
 
         if self.parcellation is None:
-            raise ValueError('Parcellation positional argument is required for ReceptorQury')
+            raise ValueError('Parcellation positional argument is required for ReceptorQuery')
         if self.__class__.__features is None:
             self._load_features()
         for feature in self.__class__.__features:

--- a/siibra/features/receptors.py
+++ b/siibra/features/receptors.py
@@ -507,10 +507,12 @@ class ReceptorQuery(FeatureExtractor):
     _FEATURETYPE = ReceptorDistribution
     __features = None
 
-    def __init__(self,atlas):
-        # TODO this could probably be a general pattern of the FeatureExtractor Class.
+    def __init__(self,**kwargs):
 
-        FeatureExtractor.__init__(self,atlas)
+        FeatureExtractor.__init__(self,**kwargs)
+
+        if self.parcellation is None:
+            raise ValueError('Parcellation positional argument is required for ReceptorQury')
         if self.__class__.__features is None:
             self._load_features()
         for feature in self.__class__.__features:

--- a/siibra/parcellation.py
+++ b/siibra/parcellation.py
@@ -187,6 +187,7 @@ class Parcellation:
         """
         return space in self.volume_src.keys()
 
+    @cached
     def decode_region(self,regionspec:Union[str,int,ParcellationIndex,Region]):
         """
         Given a unique specification, return the corresponding region.

--- a/siibra/retrieval.py
+++ b/siibra/retrieval.py
@@ -214,3 +214,19 @@ def clear_cache():
     logger.info("Clearing siibra cache.")
     shutil.rmtree(CACHEDIR)
     __compile_cachedir()
+
+def save_cache(key: str, content: bytes, force=False):
+    cache_filename=cachefile(key)
+    if os.path.exists(cache_filename) and force != True:
+        raise Exception('save_cache exception: file already exists')
+    with open(cache_filename, 'wb') as fp:
+        fp.write(content)
+    
+
+def get_cache(key: str):
+    cache_filename=cachefile(key)
+    if not os.path.exists(cache_filename):
+        raise FileNotFoundError('save_cache exception: file does not exists')
+    with open(cache_filename, 'rb') as fp:
+        return fp.read()
+    

--- a/test/test_extract_transmitter_receptor_densities.py
+++ b/test/test_extract_transmitter_receptor_densities.py
@@ -21,7 +21,7 @@ class TestExtractTransmitterReceptorDensities(unittest.TestCase):
         self.assertEqual(features[0].name, 'Density measurements of different receptors for Area hOc1 (V1, 17, CalcS) [human, v1.0]')
 
         regions = ['hOc1', 'hOc2', 'IFG']
-        query = sb.features.receptors.ReceptorQuery(atlas)
+        query = sb.features.receptors.ReceptorQuery(parcellation=atlas.selected_parcellation)
         self.assertTrue(len(query.features) >= 42)
         for q in regions:
             matched_features = [f for f in query.features if f.region.matches(q)]


### PR DESCRIPTION
This PR does two things to improve the loading time of feature extractor(s):

- reuse feature extractor (currently, each call to `atlas.get_features` results the instantiation of a new feature extractor)
- (for `EbrainsRegionalFeature` implements static method `get_cache`, which can be called ahead of time to further improve response time)

This should result in drastic improvement in:

- calling `get_feature`, especially:
  - repeated calling `get_feature` on same modality
  - if modality is ebrainsfeatures
  - if modality is ebrainsfeatures, and `get_cache` is called prior to calling `get_feature`

I will paste some performance comparison in the comments

---

**nb**

this PR also changes the way users should instantiate feature extractors.

Instead of passing the entire atlas object, one must explicitly pass parcellation and region as positional arguments, if required. The feature extractor will raise an exception if a positional argument is required, but not supplied.

This should allow caching of extractors to function properly. 