### PR TITLE
feat: add origin data info

### DIFF
--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -15,6 +15,7 @@
 import re
 from enum import Enum
 from abc import ABC, abstractmethod
+from . import logger
 
 class Glossary:
     """
@@ -78,3 +79,25 @@ class ParcellationIndex:
     def __hash__(self):
         return hash((self.map,self.label))
 
+class OriginDataInfo:
+    def __init__(self, name=None, description=None, urls=[]):
+        self.name=name
+        self.description=description
+        self.urls=urls
+
+    @staticmethod
+    def from_json(jsonstr):
+        json_type=jsonstr.get('@type')
+        if json_type == 'fzj/tmp/simpleOriginInfo/v0.0.1':
+            return OriginDataInfo(name=jsonstr.get('name'),
+                        description=jsonstr.get('description'),
+                        urls=jsonstr.get('url', []))
+        if json_type == 'minds/core/dataset/v1.0.0':
+            from .ebrains import EbrainsDatasetOriginDataInfo
+            return EbrainsDatasetOriginDataInfo(id=jsonstr.get('kgId'))
+        logger.debug(f'Cannot parse {jsonstr}')
+        return None
+
+class HasOriginDataInfo:
+    def __init__(self):
+        self.origin_datainfos = []

--- a/siibra/ebrains.py
+++ b/siibra/ebrains.py
@@ -100,6 +100,9 @@ class EbrainsDatasetOriginDataInfo(EbrainsDataset, OriginDataInfo):
     def __init__(self, id):
         EbrainsDataset.__init__(self, id=id, name=None, embargo_status=None)
 
+    def __str__(self):
+        super(EbrainsDataset, self)
+
 class Authentication(object):
     """
     Implements the authentication to EBRAINS API with an authentication token. Uses a Singleton pattern.

--- a/siibra/ebrains.py
+++ b/siibra/ebrains.py
@@ -12,11 +12,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .commons import OriginDataInfo
 from . import logger
 from .retrieval import cached_get
 import requests
 import json
 from os import environ
+import re
+
+kg_feature_full_kwargs={
+    'org': 'minds',
+    'domain': 'core',
+    'schema': 'dataset',
+    'version': 'v1.0.0'
+}
+
+kg_feature_query_kwargs={
+    'params': {
+        'vocab': 'https://schema.hbp.eu/myQuery/'
+    }
+}
+KG_REGIONAL_FEATURE_FULL_QUERY_NAME='interactiveViewerKgQuery-v1_0'
+
+class EbrainsDataset:
+    def __init__(self, id, name, embargo_status):
+        
+        self.id = id
+        self.name = name
+        self.embargo_status = embargo_status
+        self._detail = None
+
+    @property
+    def detail(self):
+        if not self._detail:
+            self._load()
+        return self._detail
+
+    def _load(self):
+        if self.id is None:
+            raise Exception('id is required')
+        match=re.search(r"([a-f0-9-]+)$", self.id)
+        if not match:
+            raise Exception('id cannot be parsed properly')
+        instance_id=match.group(1)
+        result=execute_query_by_id(
+            query_id=KG_REGIONAL_FEATURE_FULL_QUERY_NAME, 
+            instance_id=instance_id,
+            msg=f"Retrieving details for '{self.name or self.id}' from EBRAINS...",
+            **kg_feature_query_kwargs,**kg_feature_full_kwargs)
+        self._detail = result
+
+    def __str__(self):
+        return self.name
+
+
+class EbrainsDatasetOriginDataInfo(EbrainsDataset, OriginDataInfo):
+
+    @property
+    def urls(self):
+        return [{
+            'doi': f,
+        }for f in self.detail.get('kgReference', [])]
+
+    @urls.setter
+    def urls(self, val):
+        pass
+
+    @property
+    def description(self):
+        return self.detail.get('description')
+    
+    @description.setter
+    def description(self, val):
+        pass
+
+    @property
+    def name(self):
+        # to prevent inf loop, if _detail is undefined, return id
+        if self._detail is None:
+            return None
+        return self.detail.get('name')
+
+    @name.setter
+    def name(self, value):
+        pass
+
+    def __init__(self, id):
+        EbrainsDataset.__init__(self, id=id, name=None, embargo_status=None)
 
 class Authentication(object):
     """

--- a/siibra/features/ebrainsquery.py
+++ b/siibra/features/ebrainsquery.py
@@ -38,6 +38,8 @@ class EbrainsRegionalDataset(RegionalFeature, ebrains.EbrainsDataset):
         RegionalFeature.__init__(self, region)
         ebrains.EbrainsDataset.__init__(self, id, name, embargo_status)
 
+    def __str__(self):
+        super(ebrains.EbrainsDataset, self)
 
 class EbrainsRegionalFeatureExtractor(FeatureExtractor):
     _FEATURETYPE=EbrainsRegionalDataset

--- a/siibra/features/ebrainsquery.py
+++ b/siibra/features/ebrainsquery.py
@@ -24,12 +24,6 @@ IGNORE_PROJECTS = [
   'Julich-Brain: cytoarchitectonic probabilistic maps of the human brain'
 ]
 
-kg_feature_query_kwargs={
-    'params': {
-        'vocab': 'https://schema.hbp.eu/myQuery/'
-    }
-}
-
 kg_feature_summary_kwargs={
     'org': 'minds',
     'domain': 'core',
@@ -37,45 +31,12 @@ kg_feature_summary_kwargs={
     'version': 'v1.0.0'
 }
 
-kg_feature_full_kwargs={
-    'org': 'minds',
-    'domain': 'core',
-    'schema': 'dataset',
-    'version': 'v1.0.0'
-}
-
 KG_REGIONAL_FEATURE_SUMMARY_QUERY_NAME = 'siibra-kg-feature-summary-0.0.1'
-KG_REGIONAL_FEATURE_FULL_QUERY_NAME='interactiveViewerKgQuery-v1_0'
-class EbrainsRegionalDataset(RegionalFeature):
+
+class EbrainsRegionalDataset(RegionalFeature, ebrains.EbrainsDataset):
     def __init__(self, region, id, name, embargo_status):
-        self.region = region
-        self.id = id
-        self.name = name
-        self.embargo_status = embargo_status
-        self._detail = None
-
-    @property
-    def detail(self):
-        if not self._detail:
-            self._load()
-        return self._detail
-
-    def _load(self):
-        if self.id is None:
-            raise Exception('id is required')
-        match=re.search(r"\/([a-f0-9-]+)$", self.id)
-        if not match:
-            raise Exception('id cannot be parsed properly')
-        instance_id=match.group(1)
-        result=ebrains.execute_query_by_id(
-            query_id=KG_REGIONAL_FEATURE_FULL_QUERY_NAME, 
-            instance_id=instance_id,
-            msg=f"Retrieving details for '{self.name}' from EBRAINS...",
-            **kg_feature_query_kwargs,**kg_feature_full_kwargs)
-        self._detail = result
-
-    def __str__(self):
-        return self.name
+        RegionalFeature.__init__(self, region)
+        ebrains.EbrainsDataset.__init__(self, id, name, embargo_status)
 
 
 class EbrainsRegionalFeatureExtractor(FeatureExtractor):
@@ -89,7 +50,7 @@ class EbrainsRegionalFeatureExtractor(FeatureExtractor):
         # ebrains_id=atlas.selected_region.attrs.get('fullId', {}).get('kg', {}).get('kgId', None)
 
         result=ebrains.execute_query_by_id(query_id=KG_REGIONAL_FEATURE_SUMMARY_QUERY_NAME,
-            **kg_feature_query_kwargs,**kg_feature_summary_kwargs)
+            **ebrains.kg_feature_query_kwargs,**kg_feature_summary_kwargs)
 
         for r in result.get('results', []):
             for dataset in r.get('datasets', []):

--- a/siibra/parcellation.py
+++ b/siibra/parcellation.py
@@ -16,7 +16,7 @@ from . import logger, spaces, volumesrc, parcellationmap
 from .space import Space
 from .region import Region
 from .config import ConfigurationRegistry
-from .commons import create_key,MapType,ParcellationIndex
+from .commons import create_key,MapType,ParcellationIndex,HasOriginDataInfo,OriginDataInfo
 from typing import Union
 import numpy as np
 import nibabel as nib
@@ -73,7 +73,7 @@ class ParcellationVersion:
             return None
         return ParcellationVersion(obj.get('name', None), prev_id=obj.get('@prev', None), next_id=obj.get('@next', None))
 
-class Parcellation:
+class Parcellation(HasOriginDataInfo):
 
     _regiontree_cached = None
 
@@ -92,12 +92,16 @@ class Parcellation:
         modality  :  str or None
             a specification of the modality used for creating the parcellation.
         """
+        HasOriginDataInfo.__init__(self)
         self.id = identifier
         self.name = name
         self.key = create_key(name)
         self.version = version
+
+        # TODO replace by instanced methods in HasOriginDataInfo
         self.publications = []
         self.description = ""
+
         self.volume_src = {}
         self.modality = modality
         self._regiondefs = regiondefs
@@ -304,6 +308,11 @@ class Parcellation:
             p.description = obj['description']
         if 'publications' in obj:
             p.publications = obj['publications']
+
+        if 'originDatasets' in obj:
+            origin_datainfos=[OriginDataInfo.from_json(ds) for ds in obj.get('originDatasets', [])]
+            p.origin_datainfos=[f for f in origin_datainfos if f is not None]
+
         logger.debug(f'Adding parcellation "{str(p)}"')
         return p
 

--- a/siibra/space.py
+++ b/siibra/space.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .commons import create_key
+from .commons import create_key,HasOriginDataInfo,OriginDataInfo
 from .config import ConfigurationRegistry
 import numpy as np
 from . import volumesrc
@@ -23,12 +23,13 @@ from cloudvolume import Bbox
 from typing import Tuple
 import nibabel as nib
 
-class Space:
+class Space(HasOriginDataInfo):
     """
     A particular brain reference space.
     """
 
     def __init__(self, identifier, name, template_type=None, src_volume_type=None, volume_src={}):
+        HasOriginDataInfo.__init__(self)
         self.id = identifier
         self._rename(name)
         self.type = template_type
@@ -120,9 +121,12 @@ class Space:
             return obj
 
         volume_src = [volumesrc.from_json(v) for v in obj['volumeSrc']] if 'volumeSrc' in obj else []
-        return Space(obj['@id'], obj['shortName'], template_type = obj['templateType'],
+        s=Space(obj['@id'], obj['shortName'], template_type = obj['templateType'],
                 src_volume_type = obj.get('srcVolumeType'),
                 volume_src = volume_src)
+        origin_datainfos=[OriginDataInfo.from_json(f) for f in obj.get('originDatasets', [])]
+        s.origin_datainfos=[f for f in origin_datainfos if f is not None]
+        return s
 
 
 class SpaceVOI(Bbox):

--- a/test/test_atlas.py
+++ b/test/test_atlas.py
@@ -117,6 +117,12 @@ class TestAtlas(unittest.TestCase):
         # GeneExpression
         pass
 
+    def test_get_features_ebrains_features(self):
+
+        self.atlas.select_region('hoc1 left')
+        features=self.atlas.get_features(modalities.EbrainsRegionalDataset)
+        assert(len(features) > 0)
+
     def test_get_features_connectivity_profile_filter_by_sel_parc(self):
         
         expected_p_id='minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-25'


### PR DESCRIPTION
This PR adds the ability for siibra-python to parse, fetch and make available metadata related to spaces, parcellation and regions. (e.g. id added per https://jugit.fz-juelich.de/t.dickscheid/brainscapes-configurations/-/merge_requests/11/diffs?commit_id=7aa9a29a445f0d8678c47a562f2dcea124367bae )

For now, there exist two types of `origin_datainfo`, simple or ebrains. 

- simple datainfo -> name, property, urls attribute are parsed as json
- ebrains datainfo -> kgId is parsed, and the above information is fetched from KG.