### PR TITLE
chore: add coverager report to codecov

### DIFF
--- a/.github/workflows/siibra-testing.yml
+++ b/.github/workflows/siibra-testing.yml
@@ -2,12 +2,11 @@ name: Siibra testing
 
 on: [push]
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     env:
       KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
       KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
-      CI_PIPELINE: '1'
       # SIIBRA_LOG_LEVEL: DEBUG
     strategy:
       fail-fast: false
@@ -33,13 +32,33 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Install test dependencies
       run:  pip install pytest pytest-cov coverage
-    - name: Test with unittest
-      run: |
-        coverage run -m unittest
-        coverage report
-        coverage html
-    - name: Archive code coverage html report
-      uses: actions/upload-artifact@v2
+    - name: Run test with pytest
+      run: pytest
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    # always run coverage, even if test fails
+    if: ${{ always() }}
+    env:
+      KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
+      KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
       with:
-        name: siibra-python-code-coverage-report
-        path: htmlcov
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -U .
+        pip install pytest pytest-cov coverage
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Generate coverage
+      run: pytest --cov=siibra --cov-report=xml
+    - name: Upload coverage report to codecov
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __Tag_List__
 *.code-workspace
 .vscode
 playground
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG JUGEX_CLIENT_ID
 ARG JUGEX_CLIENT_SECRET
 ARG JUGEX_REFRESH_TOKEN
 ARG HBP_OIDC_ENDPOINT='https://iam.ebrains.eu/auth/realms/hbp/protocol/openid-connect/token'
-ARG CI_PIPELINE=1
 
 RUN python -m pip install --upgrade pip
 


### PR DESCRIPTION
coverage can then be seen at:

https://app.codecov.io/gh/FZJ-INM1-BDA/siibra-python

(right now it's empty, It's possible that the default branch needs to be codecov'ed before anything will show on the dash board. 

This commit has the following report:

https://codecov.io/gh/FZJ-INM1-BDA/siibra-python/commit/74437eb7c96f43ba5c26bd553447130b3827899c/