### PR TITLE
Feature/surface access

### DIFF
--- a/examples/Accessing templates and maps.ipynb
+++ b/examples/Accessing templates and maps.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Intro: Semantic concepts, spatial objects, and image data\n",
+    "## Semantic concepts, spatial objects, and image data\n",
     "\n",
     "The main concepts in `siibra` are modelled in three levels: Semantic concepts, spatial concepts, and concrete (often image) data.\n",
     "\n",
@@ -90,9 +90,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jub_maxpm = julichbrain.get_map(mni152space,maptype=siibra.MapType.LABELLED)\n",
-    "# works also: jub_maxpm = julichbrain.get_map(\"mni152\",maptype=\"labelled\")\n",
-    "jub_pmaps = julichbrain.get_map(mni152space,maptype=siibra.MapType.CONTINUOUS)\n",
+    "jub_maxpm = julichbrain.get_map(mni152space, maptype=siibra.MapType.LABELLED)\n",
+    "# works as well: jub_maxpm = julichbrain.get_map(\"mni152\",maptype=\"labelled\")\n",
+    "jub_pmaps = julichbrain.get_map(mni152space, maptype=siibra.MapType.CONTINUOUS)\n",
     "type(jub_maxpm), type(jub_pmaps)"
    ]
   },
@@ -111,7 +111,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plotting.plot_stat_map(jub_maxpm.fetch())"
+    "jubrain_cmap = julichbrain.get_colormap()\n",
+    "plotting.plot_roi(jub_maxpm.fetch(), cmap=jubrain_cmap)"
    ]
   },
   {
@@ -129,7 +130,7 @@
    "source": [
     "colin = siibra.spaces['colin'].get_template().fetch()\n",
     "colin_mpm = siibra.parcellations['julich'].get_map('colin').fetch()\n",
-    "plotting.plot_stat_map(colin_mpm,bg_img=colin)"
+    "plotting.plot_roi(colin_mpm,bg_img=colin, cmap=jubrain_cmap)"
    ]
   },
   {
@@ -156,6 +157,28 @@
     "tpl = bigbraintemplate.fetch(resolution_mm=0.64)\n",
     "\n",
     "plotting.view_img(img,bg_img=tpl,opacity=.4,symmetric_cmap=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4. Surface meshes\n",
+    "\n",
+    "`siibra` also provides access to surfaces. A popular reference space is the freesurfer fsaverage surface space, which comes in three variants: white matter surface, pial surface, and inflated surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "surfmap = julichbrain.get_map('fsaverage').fetch(variant=\"inflated\")\n",
+    "plotting.view_surf(\n",
+    "    [surfmap['vertices'], surfmap['faces']], \n",
+    "    surfmap['labels'], \n",
+    "    cmap=jubrain_cmap, symmetric_cmap=False, colorbar=False)"
    ]
   },
   {
@@ -193,11 +216,11 @@
    "outputs": [],
    "source": [
     "julichbrain_mpm_left = atlas.get_map(\"mni152\",\"julich-brain\").fetch()\n",
-    "plotting.plot_stat_map(julichbrain_mpm_left)\n",
+    "plotting.plot_roi(julichbrain_mpm_left, cmap=jubrain_cmap)\n",
     "# Note: using fetch_all(), we would have obtained both hemispheres\n",
     "    \n",
     "bundles_mpm = atlas.get_map(\"mni152\",\"long bundles\").fetch()\n",
-    "plotting.plot_stat_map(bundles_mpm)"
+    "plotting.plot_roi(bundles_mpm)"
    ]
   },
   {
@@ -220,7 +243,7 @@
     "\n",
     "# retrieve a continuous regional map of the selected region, if available\n",
     "v1_pmap_l = v1l.get_regional_map(\"mni152\",\"continuous\")\n",
-    "plotting.plot_stat_map(v1_pmap_l.fetch())"
+    "plotting.plot_roi(v1_pmap_l.fetch())"
    ]
   },
   {
@@ -271,7 +294,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bigbrainchunk = atlas.get_template('bigbrain').fetch(resolution_mm=0.02,voi=voi)\n",
+    "minpoint = (-3.979, -61.256, 3.906)\n",
+    "maxpt = (5.863, -55.356, -2.487)\n",
+    "voi = atlas.get_voi('bigbrain',minpoint,maxpt)\n",
+    "bigbrain = atlas.get_template('bigbrain')\n",
+    "bigbrainchunk = bigbrain.fetch(resolution_mm=0.02, voi=voi)\n",
     "plotting.view_img(bigbrainchunk,None,cmap='gray')"
    ]
   },

--- a/examples/Different species.ipynb
+++ b/examples/Different species.ipynb
@@ -95,13 +95,6 @@
     "parcellationmap = atlas.get_map(\"bigbrain\").fetch(resolution_mm=reso)\n",
     "plotting.plot_roi(parcellationmap,bg_img=bigbrain,cut_coords=[0,0,0],cmap='Set1')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Retrieve multimodal data features.ipynb
+++ b/examples/Retrieve multimodal data features.ipynb
@@ -55,6 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "\n",
     "### 2. Extract transmitter receptor densities\n",
     "\n",
     "Transmitter receptor density fingerprints are linked to brain regions by their name in the EBRAINS Knowledge Graph. Like any data feature, they are accessed using the `get_features` method of the atlas, which makes use of the current selection in the atlas. The `get_features` method knows from the specified data modality that the match is determined from the brain region identified. Receptor densities come as a nicely structured datatype. Amongst other things, they can visualize themselves in a plot.\n",
@@ -89,8 +90,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for r in siibra.get_features(atlas.get_region('v1'),'receptor'):\n",
-    "    fig = r.plot(r.regionspec)"
+    "import siibra\n",
+    "atlas = siibra.atlases.MULTILEVEL_HUMAN_ATLAS\n",
+    "r = siibra.get_features(atlas.get_region('v1'), 'receptor')[0]\n",
+    "fig = r.plot(title=r.regionspec)"
    ]
   },
   {
@@ -110,14 +113,9 @@
    "source": [
     "atlas = siibra.atlases['human']\n",
     "features = siibra.get_features(\n",
-    "    atlas.get_region('V1','julich'),\n",
+    "    atlas.get_region('v1'),\n",
     "    siibra.modalities.CorticalCellDistribution)\n",
-    "\n",
-    "N = 2\n",
-    "if N<len(features):\n",
-    "    print(f\"Plotting only {N} of {len(features)} features.\")\n",
-    "for f in features[:N]:\n",
-    "    fig = f.plot(f.regionspec)\n"
+    "fig = features[0].plot(features[0].regionspec)"
    ]
   },
   {
@@ -251,6 +249,27 @@
     "region = atlas.get_region(\"fp1 right\")\n",
     "for f in siibra.get_features(region, \"ebrains\"):\n",
     "    print(f\"{f.name}\\n{f.url}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 8. Retrieving  volumes of interest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hip = atlas.get_region(\"hippocampal\")\n",
+    "voi, *othervois = siibra.get_features(hip, siibra.modalities.VolumeOfInterest)\n",
+    "tpl = voi.space.get_template().fetch()\n",
+    "img = voi.volumes[0].fetch()\n",
+    "from nilearn import plotting\n",
+    "plotting.plot_roi(voiimg, bg_img=tpl, title=voi.name, cmap='gray',colorbar=False)"
    ]
   },
   {

--- a/examples/Walkthrough.ipynb
+++ b/examples/Walkthrough.ipynb
@@ -372,6 +372,13 @@
     "for f in features:\n",
     "    print(f.name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -16,7 +16,7 @@
 from .commons import logger, QUIET, VERBOSE
 
 # __version__ is parsed by setup.py
-__version__ = "0.3a4"
+__version__ = "0.3a5"
 logger.info(f"Version: {__version__}")
 logger.warning("This is a development release. Use at your own risk.")
 logger.info(

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -16,7 +16,7 @@
 from .commons import logger, QUIET, VERBOSE
 
 # __version__ is parsed by setup.py
-__version__ = "0.3a5"
+__version__ = "0.3a6"
 logger.info(f"Version: {__version__}")
 logger.warning("This is a development release. Use at your own risk.")
 logger.info(

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -219,7 +219,7 @@ class ParcellationIndex:
         return all([self.map == other.map, self.label == other.label])
 
     def __hash__(self):
-        return hash((self.map, self.label))
+        return hash((self.__class__.__name__, self.map, self.label))
 
 
 class MapType(Enum):
@@ -246,7 +246,7 @@ def nonzero_coordinates(arr):
 
 
 def affine_scaling(affine):
-    """Estimate approximate isotropic scaling factor of an affine matrix. """
+    """Estimate approximate isotropic scaling factor of an affine matrix."""
     orig = np.dot(affine, [0, 0, 0, 1])
     unit_lengths = []
     for vec in np.identity(3):
@@ -328,7 +328,7 @@ def compare_maps(map1: Nifti1Image, map2: Nifti1Image):
     x0 = x - mu_x
     y0 = y - mu_y
     dem = np.sqrt(np.sum(x0 ** 2) * np.sum(y0 ** 2))
-    if dem==0:
+    if dem == 0:
         r = 0
     else:
         r = np.sum(np.multiply(x0, y0)) / dem

--- a/siibra/core/atlas.py
+++ b/siibra/core/atlas.py
@@ -34,31 +34,31 @@ class Atlas(
 
     @staticmethod
     def get_species_data(species_str: str):
-        if species_str == 'human':
+        if species_str == "human":
             return {
-                '@id': 'https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/0ea4e6ba-2681-4f7d-9fa9-49b915caaac9',
-                'name': 'Homo sapiens'
+                "@id": "https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/0ea4e6ba-2681-4f7d-9fa9-49b915caaac9",
+                "name": "Homo sapiens",
             }
-        if species_str == 'rat':
+        if species_str == "rat":
             return {
-                '@id': 'https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/f3490d7f-8f7f-4b40-b238-963dcac84412',
-                'name': 'Rattus norvegicus'
+                "@id": "https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/f3490d7f-8f7f-4b40-b238-963dcac84412",
+                "name": "Rattus norvegicus",
             }
-        if species_str == 'mouse':
+        if species_str == "mouse":
             return {
-                '@id': 'https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/cfc1656c-67d1-4d2c-a17e-efd7ce0df88c',
-                'name': 'Mus musculus'
+                "@id": "https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/cfc1656c-67d1-4d2c-a17e-efd7ce0df88c",
+                "name": "Mus musculus",
             }
         # TODO this may not be correct. Wait for feedback and get more accurate
-        if species_str == 'monkey':
+        if species_str == "monkey":
             return {
-                '@id': 'https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/3f75b0ad-dbcd-464e-b614-499a1b9ae86b',
-                'name': 'Primates'
+                "@id": "https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/3f75b0ad-dbcd-464e-b614-499a1b9ae86b",
+                "name": "Primates",
             }
 
-        raise ValueError(f'species with spec {species_str} cannot be decoded')
+        raise ValueError(f"species with spec {species_str} cannot be decoded")
 
-    def __init__(self, identifier, name, species = None):
+    def __init__(self, identifier, name, species=None):
         """Construct an empty atlas object with a name and identifier."""
 
         AtlasConcept.__init__(self, identifier, name, dataset_specs=[])
@@ -195,12 +195,23 @@ class Atlas(
         """
         return self.get_parcellation(parcellation).decode_region(region)
 
-    def get_template(self, space: Space = None):
+    def get_template(self, space: Space = None, variant: str = None):
         """
         Returns the reference template in the desired reference space.
         If no reference space is given, the default from `Atlas.space()` is used.
+
+        Parameters
+        ----------
+        space: Space
+            The desired reference space
+        variant: str (optional)
+            Some templates are provided in different variants, e.g.
+            freesurfer is available as either white matter, pial or
+            inflated surface for left and right hemispheres (6 variants).
+            This field could be used to request a specific variant.
+            Per default, the first found variant is returned.
         """
-        return self.get_space(space).get_template()
+        return self.get_space(space).get_template(variant=variant)
 
     def get_voi(self, space: Space, point1: tuple, point2: tuple):
         """Get a volume of interest spanned by two points in the given reference space.
@@ -226,7 +237,7 @@ class Atlas(
         all_versions=False,
         filter_children=True,
         build_groups=False,
-        groupname=None
+        groupname=None,
     ):
         """
         Find regions with the given specification in all
@@ -261,7 +272,7 @@ class Atlas(
                     regionspec,
                     filter_children=filter_children,
                     build_group=build_groups,
-                    groupname=groupname
+                    groupname=groupname,
                 )
                 if build_groups:
                     if match is not None:

--- a/siibra/core/concept.py
+++ b/siibra/core/concept.py
@@ -181,7 +181,7 @@ class AtlasConcept:
         """
         The list of available datasets representing image volumes.
         """
-        return [d for d in self.datasets if d.is_image_volume]
+        return [d for d in self.datasets if d.is_volume]
 
     @property
     def has_volumes(self):
@@ -193,7 +193,7 @@ class AtlasConcept:
         """
         List of available datasets representing additional information.
         """
-        return [d for d in self.datasets if not d.is_image_volume]
+        return [d for d in self.datasets if not d.is_volume]
 
     @property
     def publications(self):

--- a/siibra/core/datasets.py
+++ b/siibra/core/datasets.py
@@ -42,9 +42,12 @@ class Dataset:
         cls.type_id = type_id
 
     @property
-    def is_image_volume(self):
-        """Overwritten by derived dataset classes in the siibra.volumes"""
-        return False
+    def is_volume(self):
+        """Return True if this dataset is derived from siibra.volumes.VolumeSrc.
+        
+        We use string matching of the class name to avoid importing the module.
+        """
+        return "VolumeSrc" in [t.__name__ for t in type(self).__mro__]
 
     @property
     def publications(self):

--- a/siibra/core/parcellation.py
+++ b/siibra/core/parcellation.py
@@ -227,16 +227,18 @@ class Parcellation(
         """Generate a matplotlib colormap from known rgb values of label indices."""
         from matplotlib.colors import ListedColormap
         import numpy as np
+
         colors = {
-            r.index.label:r.attrs['rgb'] 
-            for r in self.regiontree 
-            if 'rgb' in r.attrs and r.index.label
+            r.index.label: r.attrs["rgb"]
+            for r in self.regiontree
+            if "rgb" in r.attrs and r.index.label
         }
-        pallette = np.array([
-            colors[i]+[1] 
-            if i in colors else [0,0,0,0] 
-            for i in range(max(colors.keys())+1)
-        ]) / [255,255,255,1]
+        pallette = np.array(
+            [
+                colors[i] + [1] if i in colors else [0, 0, 0, 0]
+                for i in range(max(colors.keys()) + 1)
+            ]
+        ) / [255, 255, 255, 1]
         return ListedColormap(pallette)
 
     def supports_space(self, space: Space):
@@ -335,12 +337,22 @@ class Parcellation(
             regionspec,
             filter_children=filter_children,
             build_group=build_group,
-            groupname=groupname
+            groupname=groupname,
         )
 
         # Perform ranking of return result, if the spec provided is a string. Otherwise, return the unsorted found_regions
         # reverse is set to True, since SequenceMatcher().ratio(), higher == better
-        return sorted(found_regions,reverse=True, key=lambda region: difflib.SequenceMatcher(None, str(region), regionspec).ratio()) if type(regionspec) == str else found_regions
+        return (
+            sorted(
+                found_regions,
+                reverse=True,
+                key=lambda region: difflib.SequenceMatcher(
+                    None, str(region), regionspec
+                ).ratio(),
+            )
+            if type(regionspec) == str
+            else found_regions
+        )
 
     def __str__(self):
         return self.name

--- a/siibra/core/parcellation.py
+++ b/siibra/core/parcellation.py
@@ -223,6 +223,22 @@ class Parcellation(
     def names(self):
         return self.regiontree.names
 
+    def get_colormap(self):
+        """Generate a matplotlib colormap from known rgb values of label indices."""
+        from matplotlib.colors import ListedColormap
+        import numpy as np
+        colors = {
+            r.index.label:r.attrs['rgb'] 
+            for r in self.regiontree 
+            if 'rgb' in r.attrs and r.index.label
+        }
+        pallette = np.array([
+            colors[i]+[1] 
+            if i in colors else [0,0,0,0] 
+            for i in range(max(colors.keys())+1)
+        ]) / [255,255,255,1]
+        return ListedColormap(pallette)
+
     def supports_space(self, space: Space):
         """
         Return true if this parcellation supports the given space, else False.

--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -360,7 +360,7 @@ class Region(anytree.NodeMixin, AtlasConcept):
                 M = self.parcellation.get_map(space, maptype=maptype)
                 M.decode_region(self)
                 return True
-            except (ValueError, IndexError):
+            except (ValueError, IndexError, TypeError):
                 pass
         return False
 

--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -150,7 +150,7 @@ class Region(anytree.NodeMixin, AtlasConcept):
         """
         Identify each region by its parcellation and region key.
         """
-        return hash(self.parcellation.key + self.key)
+        return hash((self.parcellation.key, self.key, self.index)) 
 
     def has_parent(self, parent):
         return parent in [a for a in self.ancestors]

--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -150,7 +150,7 @@ class Region(anytree.NodeMixin, AtlasConcept):
         """
         Identify each region by its parcellation and region key.
         """
-        return hash((self.parcellation.key, self.key, self.index)) 
+        return hash((self.parcellation.key, self.key)) 
 
     def has_parent(self, parent):
         return parent in [a for a in self.ancestors]

--- a/siibra/core/space.py
+++ b/siibra/core/space.py
@@ -53,21 +53,37 @@ class Space(
         self.type = template_type
         self.atlases = set()
 
-    def get_template(self):
+    def get_template(self, variant=None):
         """
-        Get the volumetric reference template image for this space.
+        Get the volumetric reference template for this space.
 
+        Parameters
+        ----------
+        variant: str (optional)
+            Some templates are provided in different variants, e.g. 
+            freesurfer is available as either white matter, pial or 
+            inflated surface for left and right hemispheres (6 variants).
+            This field could be used to request a specific variant. 
+            Per default, the first found variant is returned.        
+        
         Yields
         ------
-        A nibabel Nifti object representing the reference template, or None if not available.
-        TODO Returning None is not ideal, requires to implement a test on the other side.
+        A VolumeSrc object representing the reference template, or None if not available.
         """
-        candidates = [vsrc for vsrc in self.volumes if vsrc.volume_type == self.type]
-        if not len(candidates) == 1:
-            raise RuntimeError(
-                f"Could not resolve template image for {self.name}. This is most probably due to a misconfiguration of the volume src."
+        candidates = {d.name:d for d in self.datasets if d.is_volume and d.volume_type==self.type}
+        if variant is None:
+            variant = next(iter(candidates.keys()))
+            logger.warn(
+                f"Multiple template variants available for {self.name}. "
+                f"Returning the first, '{variant}', but you could have chosen "
+                f"any of {', '.join(candidates.keys())}."
             )
-        return candidates[0]
+        if variant not in candidates.keys():
+            raise RuntimeError(
+                f"Template variant '{variant}' not available for {self.name}. "
+                f"Available variants are {', '.join(candidates.keys())}")
+
+        return candidates[variant]
 
     def __getitem__(self, slices):
         """

--- a/siibra/features/cells.py
+++ b/siibra/features/cells.py
@@ -32,10 +32,10 @@ class CorticalCellDistribution(RegionalFeature):
     Implements lazy and cached loading of actual data.
     """
 
-    def __init__(self, regionspec, cells, connector, folder):
+    def __init__(self, regionspec, cells, connector, folder, species):
 
         _, section_id, patch_id = folder.split("/")
-        RegionalFeature.__init__(self, regionspec)
+        RegionalFeature.__init__(self, regionspec, species)
         self.cells = cells
         self.section = section_id
         self.patch = patch_id
@@ -166,6 +166,11 @@ class RegionalCellDensityExtractor(FeatureQuery):
             f"PREVIEW DATA! {self._FEATURETYPE.__name__} data is only a pre-release snapshot. Contact support@ebrains.eu if you intend to use this data."
         )
 
+        species = {
+            '@id': 'https://nexus.humanbrainproject.org/v0/data/minds/core/species/v1.0.0/0ea4e6ba-2681-4f7d-9fa9-49b915caaac9',
+            'name': 'Homo sapiens'
+        }
+
         for cellfile, loader in self._JUGIT.get_loaders(
             suffix="segments.txt", recursive=True
         ):
@@ -185,5 +190,5 @@ class RegionalCellDensityExtractor(FeatureQuery):
                 ]
             )
             self.register(
-                CorticalCellDistribution(regionspec, cells, self._SCIEBO, region_folder)
+                CorticalCellDistribution(regionspec, cells, self._SCIEBO, region_folder, species)
             )

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -181,7 +181,7 @@ class RegionalFeature(Feature):
     TODO store region as an object that has a link to the parcellation
     """
 
-    def __init__(self, regionspec: Tuple[str, Region], species = [], **kwargs):
+    def __init__(self, regionspec: Tuple[str, Region], species: dict, **kwargs):
         """
         Parameters
         ----------

--- a/siibra/features/genes.py
+++ b/siibra/features/genes.py
@@ -174,7 +174,6 @@ class AllenBrainAtlasQuery(FeatureQuery):
                 # When the Allen site is not available, they still send a status code 200.
                 raise RuntimeError(f"Allen institute site unavailable - please try again later.")
             root = ElementTree.fromstring(response)
-            print(root.attrib.keys())
             num_probes = int(root.attrib["total_rows"])
             probe_ids = [int(root[0][i][0].text) for i in range(num_probes)]
 

--- a/siibra/features/query.py
+++ b/siibra/features/query.py
@@ -15,7 +15,7 @@
 
 from .feature import Feature
 
-from .. import logger
+from .. import logger, QUIET
 from ..commons import Registry
 from ..core import AtlasConcept, Dataset
 
@@ -133,9 +133,10 @@ class FeatureQuery(ABC):
         Executes a query for features associated with an atlas object.
         """
         matches = []
-        for feature in self.features:
-            if feature.match(concept):
-                matches.append(feature)
+        with QUIET:
+            for feature in self.features:
+                if feature.match(concept):
+                    matches.append(feature)
         return matches
 
     def __str__(self):

--- a/siibra/volumes/__init__.py
+++ b/siibra/volumes/__init__.py
@@ -13,5 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .parcellationmap import ParcellationMap, LabelledParcellationMap, ContinuousParcellationMap
+from .parcellationmap import ParcellationVolume, LabelledParcellationVolume, ContinuousParcellationVolume
 from .volume import VolumeSrc, NeuroglancerVolume, RemoteNiftiVolume, LocalNiftiVolume
+from .mesh import  GiftiSurfaceLabeling, NeuroglancerMesh, GiftiSurface

--- a/siibra/volumes/mesh.py
+++ b/siibra/volumes/mesh.py
@@ -1,0 +1,95 @@
+# Copyright 2018-2021
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .volume import VolumeSrc
+
+from ..retrieval import LazyHttpRequest
+
+import numpy as np
+
+class GiftiSurface(VolumeSrc, volume_type="gii"):
+    """
+    A (set of) surface meshes in Gifti format.
+    """
+    def __init__(self, identifier, name, url, space, detail=None, **kwargs):
+        VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
+        if isinstance(url, str):
+            # a single url
+            self._loaders = {name: url}
+        elif isinstance(url, dict):
+            self._loaders = {
+                label: LazyHttpRequest(url)
+                for label, url in url.items()
+            } 
+        else:
+            raise NotImplementedError(f"Urls for {self.__class__.__name__} are expected to be of type str or dict.")
+
+    def fetch(self, name=None):
+        """
+        Returns the mesh as a dictionary with two numpy arrays: An Nx3 array of vertex coordinates, 
+        and an Mx3 array of face definitions using row indices of the vertex array.
+
+        If name is specified, only submeshes matching this name are included, otherwise all meshes are combined.
+        """
+        vertices = np.empty((0, 3))
+        faces = np.empty((0,3), dtype='int')
+        for n, loader in self._loaders.items():
+            npoints = vertices.shape[0]
+            if (name is not None) & (n!=name):
+                continue
+            assert len(loader.data.darrays)>1
+            vertices = np.append(vertices, loader.data.darrays[0].data, axis = 0)
+            faces = np.append(faces, loader.data.darrays[1].data+npoints, axis = 0)
+
+        return dict(zip(['verts','faces'], [vertices, faces]))
+
+    @property
+    def variants(self):
+        return list(self._loaders.keys())
+
+    def fetch_iter(self):
+        """
+        Iterator returning all submeshes, each as a tuple consisting of 
+        - their name (string)
+        - the mesh, as a dictionary of two numpy arrays: 
+          An Nx3 array of vertex coordinates, and an Mx3 array 
+          of face definitions using row indices of the vertex array.
+        """
+        return ((v,self.fetch(v)) for v in self.variantss)
+
+class GiftiSurfaceLabeling(VolumeSrc, volume_type="gii-label"):
+    """
+    A mesh labeling, specified by a gifti file.
+    """
+    def __init__(self, identifier, name, url, space, detail=None, **kwargs):
+        VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
+        self._loader = LazyHttpRequest(self.url)
+
+    def fetch(self):
+        """Returns a 1D numpy array of label indices."""
+        assert(len(self._loader.data.darrays)==1)
+        return self._loader.data.darrays[0].data
+
+
+class NeuroglancerMesh(VolumeSrc, volume_type="neuroglancer/precompmesh"):
+    """
+    A surface mesh provided as neuroglancer precomputed mesh.     
+    """
+
+    def __init__(self, identifier, name, url, space, detail=None, **kwargs):
+        VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
+
+    def fetch(self):
+        raise NotImplementedError(f"Fetching from neuroglancer precomputed mesh is not yet implemented.")

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -468,7 +468,7 @@ class LabelledParcellationVolume(ParcellationVolume):
                 with QUIET:
                     m = self._maploaders_cached[mapindex](res=None, voi=None, variant=None)
                 unmatched = []
-                for labelindex in np.unique(m.get_fdata()):
+                for labelindex in np.unique(np.asanyarray(m.dataobj)):
                     if labelindex != 0:
                         pindex = ParcellationIndex(map=mapindex, label=labelindex)
                         try:

--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -84,13 +84,6 @@ class VolumeSrc(Dataset, type_id="fzj/tmp/volume_type/v0.0.1"):
     def __str__(self):
         return f"{self.volume_type} {self.url}"
 
-    def get_url(self):
-        return self.url
-
-    @property
-    def is_image_volume(self):
-        return True
-
     @classmethod
     def _from_json(cls, obj):
         """
@@ -111,7 +104,7 @@ class VolumeSrc(Dataset, type_id="fzj/tmp/volume_type/v0.0.1"):
             if "transform" in detail["neuroglancer/precomputed"]:
                 transform_nm = np.array(detail["neuroglancer/precomputed"]["transform"])
 
-        # decide if object shoulc be generated with a specialized derived class
+        # decide if object should be generated with a specialized derived class
         VolumeClass = cls._SPECIALISTS.get(volume_type, cls)
         kwargs = {
             "transform_nm": transform_nm,
@@ -203,11 +196,6 @@ class LocalNiftiVolume(ImageProvider):
     def is_float(self):
         return self.image.dataobj.dtype.kind == "f"
 
-    @property
-    def is_image_volume(self):
-        return True
-
-
 class RemoteNiftiVolume(ImageProvider, VolumeSrc, volume_type="nii"):
 
     _image_cached = None
@@ -295,7 +283,6 @@ class RemoteNiftiVolume(ImageProvider, VolumeSrc, volume_type="nii"):
     def is_float(self):
         return self.image.dataobj.dtype.kind == "f"
 
-
 class NeuroglancerVolume(
     ImageProvider, VolumeSrc, volume_type="neuroglancer/precomputed"
 ):
@@ -318,6 +305,7 @@ class NeuroglancerVolume(
         ngsite: base url of neuroglancer http location
         transform_nm: optional transform to be applied after scaling voxels to nm
         """
+        assert isinstance(url,str)
         super().__init__(identifier, name, url, space, detail)
         self.transform_nm = transform_nm
         self.info = HttpRequest(url + "/info", lambda b: json.loads(b.decode())).get()
@@ -579,69 +567,3 @@ class DetailedMapsVolume(VolumeSrc, volume_type="detailed maps"):
 
     def __init__(self, identifier, name, url, space, detail=None, **kwargs):
         VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
-
-
-class GiftiSurfaceLabeling(VolumeSrc, volume_type="threesurfer/gii-label"):
-    """
-    TODO Implement this, surfaces need special handling
-    """
-
-    warning_shown = False
-
-    def __init__(self, identifier, name, url, space, detail=None, **kwargs):
-        if not self.__class__.warning_shown:
-            logger.info(
-                f"A {self.__class__.__name__} object was registered, "
-                "but this type is not yet explicitly supported."
-            )
-            self.__class__.warning_shown = True
-        VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
-
-    @property
-    def is_image_volume(self):
-        """ Meshes are not volumes. """
-        return False
-
-
-class GiftiSurface(VolumeSrc, volume_type="threesurfer/gii"):
-    """
-    TODO Implement this, surfaces need special handling
-    """
-
-    warning_shown = False
-
-    def __init__(self, identifier, name, url, space, detail=None, **kwargs):
-        if not self.__class__.warning_shown:
-            logger.info(
-                f"A {self.__class__.__name__} object was registered, "
-                "but this type is not yet explicitly supported."
-            )
-            self.__class__.warning_shown = True
-        VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
-
-    @property
-    def is_image_volume(self):
-        """ Meshes are not volumes. """
-        return False
-
-
-class NeuroglancerMesh(VolumeSrc, volume_type="neuroglancer/precompmesh"):
-    """
-    TODO Implement this, surfaces need special handling
-    """
-
-    warning_shown = False
-
-    def __init__(self, identifier, name, url, space, detail=None, **kwargs):
-        if not self.__class__.warning_shown:
-            logger.info(
-                f"A {self.__class__.__name__} object was registered, "
-                "but this type is not yet explicitly supported."
-            )
-            self.__class__.warning_shown = True
-        VolumeSrc.__init__(self, identifier, name, url, space, detail, **kwargs)
-
-    @property
-    def is_image_volume(self):
-        """ Meshes are not volumes. """
-        return False

--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -196,6 +196,9 @@ class LocalNiftiVolume(ImageProvider):
     def is_float(self):
         return self.image.dataobj.dtype.kind == "f"
 
+    def is_volume(self):
+        return True
+
 class RemoteNiftiVolume(ImageProvider, VolumeSrc, volume_type="nii"):
 
     _image_cached = None

--- a/test/volumes/test_volume_src.py
+++ b/test/volumes/test_volume_src.py
@@ -11,7 +11,7 @@ class TestVolumeSrc(unittest.TestCase):
         url = "http://localhost/test"
         volume_src = VolumeSrc(id, name, url, spaces[0])
         self.assertIsNotNone(volume_src)
-        self.assertEqual(volume_src.get_url(), url)
+        self.assertEqual(volume_src.url, url)
 
     def test_volume_from_valid_json(self):
         v_json = {


### PR DESCRIPTION
This PR adds explicit basic surface support:

- new module volumes.mesh
- classes for Gifti meshes and Gifti labels (neuroglancer meshes not yet completely supported)
- clearer distinction of volumes and image volumes (meshes are also volumes, but not image volumes)

I have chosen to return meshes as a dict of two arrays - 'verts' and 'faces'.  The mesh "fetch()" method allows to specify variants, in order to select e.g. white matter, pial, or inflated.

An Example:

```python
import siibra
atlas = siibra.atlases['human']
julich_cmap = atlas.get_parcellation().get_colormap()
julich_surf = atlas.get_map(space="fsaverage").fetch_all(variant='inflated')
# yields a dict with three arrays: verts, faces, labels

from nilearn import plotting
plotting.view_surf(
    surf_mesh=[julich_surf['verts'], julich_surf['faces']], 
    surf_map=julich_surf['labels'],
    cmap=julich_cmap, symmetric_cmap=False, colorbar=False)
```




