### PR TITLE
bugfix: ieeg feature query space filtering & more predictable region.defined_in_space behaviour

### DIFF
--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -365,7 +365,7 @@ class Region(anytree.NodeMixin, AtlasConcept):
             except RuntimeError as e:
                 # in the event that a malformed space is passed, return False
                 # passing malformed space to self.parcellation.get_map raises Runtimeerror
-                logger.debug(f'defined_in_space RunTimeError', e)
+                logger.debug(f'defined_in_space RunTimeError: {str(e)}')
                 pass
         return False
 
@@ -381,7 +381,10 @@ class Region(anytree.NodeMixin, AtlasConcept):
         """
         Tests wether a specific map of this region is available.
         """
-        return self.get_regional_map(space, maptype) is not None
+        try:
+            return self.get_regional_map(space, maptype) is not None
+        except RuntimeError:
+            return False
 
     # @cached
     def get_regional_map(self, space: Space, maptype: Union[str, MapType]):

--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -349,7 +349,7 @@ class Region(anytree.NodeMixin, AtlasConcept):
 
         return mask
 
-    def defined_in_space(self, space):
+    def defined_in_space(self, space) -> bool:
         """
         Verifies wether this region is defined by a labelled map in the given space.
         """
@@ -361,6 +361,11 @@ class Region(anytree.NodeMixin, AtlasConcept):
                 M.decode_region(self)
                 return True
             except (ValueError, IndexError):
+                pass
+            except RuntimeError as e:
+                # in the event that a malformed space is passed, return False
+                # passing malformed space to self.parcellation.get_map raises Runtimeerror
+                logger.debug(f'defined_in_space RunTimeError', e)
                 pass
         return False
 

--- a/siibra/features/ieeg.py
+++ b/siibra/features/ieeg.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 from .feature import SpatialFeature
 from .query import FeatureQuery
 
@@ -203,9 +204,10 @@ class IEEG_SessionQuery(FeatureQuery):
     _FEATURETYPE = IEEG_Session
     _CONNECTOR = GitlabConnector("https://jugit.fz-juelich.de", 3009, "master")
 
-    def __init__(self,**kwargs):
-
+    def __init__(self, space=None, **kwargs):
         FeatureQuery.__init__(self)
+        self.space_of_interest = space
+
         dset = IEEG_Dataset._from_json(
             self._CONNECTOR.get_loader("ieeg_contact_points/info.json").data
         )
@@ -222,6 +224,11 @@ class IEEG_SessionQuery(FeatureQuery):
                 for contact_point_id, coord in contact_points.items():
                     electrode.new_contact_point(contact_point_id, coord)
             self.register(session)
+
+
+    def execute(self, concept):
+        matches: List[IEEG_Session] = super().execute(concept)
+        return [m for m in matches if not self.space_of_interest or m.space == self.space_of_interest]
 
 
 if __name__ == "__main__":

--- a/test/features/test_ieeg.py
+++ b/test/features/test_ieeg.py
@@ -1,0 +1,32 @@
+import unittest
+from siibra.features.ieeg import IEEG_SessionQuery
+import siibra
+from siibra.core import Atlas
+
+class TestIEEGSessionQuery(unittest.TestCase):
+    colin_spc_query = None
+    mni_spc_query = None
+    no_spc_query = None
+
+    hoc1_right = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.colin_spc_query = IEEG_SessionQuery(space=siibra.spaces['colin'])
+        cls.mni_spc_query = IEEG_SessionQuery(space=siibra.spaces['mni152'])
+        cls.no_spc_query = IEEG_SessionQuery()
+        
+        atlas: Atlas = siibra.atlases['human']
+        cls.hoc1_right = atlas.get_region('hoc1 right', parcellation='2 9')
+
+    def test_no_spc_returns_all(self):
+        result = self.no_spc_query.execute(self.hoc1_right)
+        assert len(result) > 0
+
+    def test_colin_return_none(self):
+        result = self.colin_spc_query.execute(self.hoc1_right)
+        assert len(result) == 0
+
+    def test_mni_returns_all(self):
+        result = self.mni_spc_query.execute(self.hoc1_right)
+        assert len(result) > 0


### PR DESCRIPTION
this PR fixes two issues:
- provides some predictability to `Region.has_regional_map` method (prior, it may raise `RuntimeError` if space provided has no suitable maps)
- fixes ieeg session query based on provided `space` kwarg 

@ reviewers, it could be argued that all spatial queries should adopt the proposed change. Should I amend the PR as such?