### PR TITLE
reduce number of features for connectivity test

### DIFF
--- a/test/features/test_connectivity.py
+++ b/test/features/test_connectivity.py
@@ -28,7 +28,7 @@ queries_tuple = (
 queries_features_tuple = (
     feat
     for Query in queries_tuple
-    for feat in Query().features
+    for feat in Query().features[:10]
 )
 
 @pytest.mark.parametrize('conn_feat', queries_features_tuple)


### PR DESCRIPTION
@xgui3783 
I saw that the tests are running over 1 hour. The connectivity tests are the one that cumsumes most of the time.
Does it make sense to run the tests over all features? I changed it to 10 for each Query. Now the pipeline is done in 12 minutes.