### PR TITLE
Refactor v0.4 layer thickness

### DIFF
--- a/siibra/volumes/gifti.py
+++ b/siibra/volumes/gifti.py
@@ -15,7 +15,6 @@
 
 from . import volume
 
-from ..commons import logger
 from ..retrieval import requests
 from ..locations import boundingbox
 

--- a/siibra/volumes/gifti.py
+++ b/siibra/volumes/gifti.py
@@ -73,9 +73,6 @@ class GiftiSurface(volume.VolumeProvider, srctype="gii-mesh"):
         """
         return (self.fetch(v) for v in self.variants)
 
-    def find_layer_thickness(self, layer0: int = 1, layer1: int = None):
-        raise NotImplementedError("Calculation of layer thickness from Gifti meshes is not yet implemented.")
-
 
 class GiftiSurfaceLabeling(volume.VolumeProvider, srctype="gii-label"):
     """

--- a/siibra/volumes/gifti.py
+++ b/siibra/volumes/gifti.py
@@ -15,6 +15,7 @@
 
 from . import volume
 
+from ..commons import logger
 from ..retrieval import requests
 from ..locations import boundingbox
 
@@ -72,6 +73,9 @@ class GiftiSurface(volume.VolumeProvider, srctype="gii-mesh"):
         - 'name': Name of the of the mesh variant
         """
         return (self.fetch(v) for v in self.variants)
+
+    def find_layer_thickness(self, layer0: int = 1, layer1: int = None):
+        raise NotImplementedError("Calculation of layer thickness from Gifti meshes is not yet implemented.")
 
 
 class GiftiSurfaceLabeling(volume.VolumeProvider, srctype="gii-label"):

--- a/siibra/volumes/neuroglancer.py
+++ b/siibra/volumes/neuroglancer.py
@@ -359,25 +359,11 @@ class NeuroglancerMesh(volume.VolumeProvider, srctype="neuroglancer/precompmesh"
             vertices = np.concatenate((data[0][0], data[1][0]))
             faces = np.concatenate((data[0][1], data[1][1] + len(data[0][0])))
         elif hemisphere.casefold() == "left":
-            (vertices, faces) = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[0]}", transform_nm)
+            vertices, faces = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[0]}", transform_nm)
         elif hemisphere.casefold() == "right":
-            (vertices, faces) = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[1]}", transform_nm)
+            vertices, faces = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[1]}", transform_nm)
         else:
             raise RuntimeError(f"hemisphere={hemisphere} is not a valid option. Options are 'left', 'right', or 'all'.")
 
-        logger.warn("Labels are not yet implemented.")
+        logger.warn("Labels are not yet implemented for Neuroglancer meshes.")
         return dict(zip(['verts', 'faces', 'name'], [vertices, faces, name]))
-    
-    def find_layer_thickness(self, meshindex_0: int = 0, meshindex_1: int = None):
-        """
-        Returns a dictionary with keys as the hemisphere and
-        the value of the thickness of the given layers.
-        """
-        # TODO: implement cache check
-        mesh_0 = self.fetch(meshindex=meshindex_0)
-        if meshindex_1 is None:
-            meshindex_1 = 7
-            logger.warn(f"Second layer is not given. Automatically selecting non-cortical layer.")
-        mesh_1 = self.fetch(meshindex=meshindex_1)
-
-        return np.linalg.norm(mesh_0["verts"] - mesh_1["verts"], axis=1)

--- a/siibra/volumes/neuroglancer.py
+++ b/siibra/volumes/neuroglancer.py
@@ -358,9 +358,8 @@ class NeuroglancerMesh(volume.VolumeProvider, srctype="neuroglancer/precompmesh"
             name = "whole"
             mesh_fragment_left = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[0]}", transform_nm)
             mesh_fragment_right = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[1]}", transform_nm)
-
             vertices = np.concatenate((mesh_fragment_left[0], mesh_fragment_right[0]))
-            faces = np.concatenate((mesh_fragment_left[1], mesh_fragment_right[1] + len(mesh_fragment_left[1])) )
+            faces = np.concatenate((mesh_fragment_left[1], mesh_fragment_right[1] + len(mesh_fragment_left[0])) )
         elif hemisphere.casefold() == "left":
             name = "left"
             (vertices, faces) = self._fetch_fragment(f"{self.url}/{self.mesh_key}/{fragments[0]}", transform_nm)
@@ -370,24 +369,13 @@ class NeuroglancerMesh(volume.VolumeProvider, srctype="neuroglancer/precompmesh"
 
         logger.warn("Labels are not yet implemented.")
         return dict(zip(['verts', 'faces', 'name'], [vertices, faces, name]))
-        
-        
-
-    @property
-    def variants(self):
-        return list(self._loaders.keys()) # rewrite the code above to have _loaders instead
-
-    def fetch_iter(self):
-        return (self.fetch(v) for v in self.variants)
     
- 
     def find_layer_thickness(self, meshindex_0: int = 0, meshindex_1: int = None):
         """
         Returns a dictionary with keys as the hemisphere and
         the value of the thickness of the given layers.
         """
         # TODO: implement cache check
-        print(type(self))
         mesh_0 = self.fetch(meshindex=meshindex_0)
         if meshindex_1 is None:
             meshindex_1 = 7

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -239,7 +239,8 @@ class Map(region.Region, configuration_folder="maps"):
         variant: str = None,
         format: str = None,
         index: MapIndex = None,
-        regionspec: str = None
+        regionspec: str = None,
+        **kwargs
     ):
         """
         Fetches one particular volume of this parcellation map.
@@ -309,6 +310,7 @@ class Map(region.Region, configuration_folder="maps"):
                 voi=voi,
                 variant=variant,
                 meshindex=mapindex.label,
+                **kwargs,
             )
             
         except requests.SiibraHttpRequestError:

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -340,6 +340,10 @@ class Map(region.Region, configuration_folder="maps"):
             )
         raise RuntimeError(f"Error fetching {mapindex} from {self} as {format}.")
 
+    def find_layer_thickness(self, mesh_0: dict, mesh_1: dict):
+        """Returns a 1D numpy array with the thickness of the given layers."""
+        return np.linalg.norm(mesh_0["verts"] - mesh_1["verts"], axis=1)
+
     @property
     def is_surface(self):
         return all(v.is_surface for v in self.volumes)


### PR DESCRIPTION
- Thickness of meshes can now be found using a map instance.
- The whole brain can be fetched (default behavior now) from Neuroglancer meshes
- Includes some cleaning in neuroglancer.py
(Sample code is available in rocketchat)