### PR TITLE
Added a get_region_colormap method to be able to show selected region in color

### DIFF
--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -532,6 +532,28 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
         ) / [255, 255, 255, 1]
         return ListedColormap(pallette)
 
+    def get_region_colormap(self, regionname):
+        """Generate a matplotlib colormap from known rgb values of label indices for a given region."""
+        from matplotlib.colors import ListedColormap
+        import numpy as np
+
+        colors = {}
+        indices = self._indices[regionname]
+        for index in indices:
+            if index.label is None:
+                continue
+            region = self.get_region(index=index)
+            if region.rgb is not None:
+                colors[index.label] = region.rgb
+
+        pallette = np.array(
+            [
+                list(colors[i]) + [1] if i in colors else [0, 0, 0, 0]
+                for i in range(max(colors.keys()) + 1)
+            ]
+        ) / [255, 255, 255, 1]
+        return ListedColormap(pallette)
+        
     def sample_locations(self, regionspec, numpoints: int):
         """ Sample 3D locations inside a given region.
 


### PR DESCRIPTION
A method suggestion, based on `get_colormap()`, to show fetched regions and meshes in color when available. Could be useful when displaying the full map and a few individual regions.

Example code
```python
import siibra
import numpy as np
from nilearn import plotting
m = siibra.get_map(parcellation="v2.9", space="MNI colin 27")
spec = m.regions[np.random.randint(0, len(m.regions) - 1)]
print(spec)
region_cmap = m.get_region_colormap(spec)
mesh = m.fetch(region=spec, format="mesh")
plotting.view_surf((mesh["verts"], mesh["faces"]), cmap=region_cmap )
```