### PR TITLE
Added an optional param to get_colormap to get the colormap of a single region

### DIFF
--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -510,39 +510,23 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
 
         return Nifti1Image(result, affine)
 
-    def get_colormap(self):
+    def get_colormap(self, region_spec=None):
         """Generate a matplotlib colormap from known rgb values of label indices."""
         from matplotlib.colors import ListedColormap
         import numpy as np
 
         colors = {}
-        for regionname, indices in self._indices.items():
-            for index in indices:
-                if index.label is None:
-                    continue
-                region = self.get_region(index=index)
-                if region.rgb is not None:
-                    colors[index.label] = region.rgb
-
-        pallette = np.array(
-            [
-                list(colors[i]) + [1] if i in colors else [0, 0, 0, 0]
-                for i in range(max(colors.keys()) + 1)
-            ]
-        ) / [255, 255, 255, 1]
-        return ListedColormap(pallette)
-
-    def get_region_colormap(self, regionname):
-        """Generate a matplotlib colormap from known rgb values of label indices for a given region."""
-        from matplotlib.colors import ListedColormap
-        import numpy as np
-
-        colors = {}
-        indices = self._indices[regionname]
-        for index in indices:
-            if index.label is None:
-                continue
-            region = self.get_region(index=index)
+        if region_spec is None:
+            for regionname, indices in self._indices.items():
+                for index in indices:
+                    if index.label is None:
+                        continue
+                    region = self.get_region(index=index)
+                    if region.rgb is not None:
+                        colors[index.label] = region.rgb
+        else:
+            region = self.parcellation.get_region(region_spec)
+            index = self._indices[region.name][0]
             if region.rgb is not None:
                 colors[index.label] = region.rgb
 

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -23,13 +23,13 @@ from .._retrieval import requests
 
 import numpy as np
 from tqdm import tqdm
-from typing import Union, Dict, List, TYPE_CHECKING
+from typing import Union, Dict, List, TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
     from ..core.region import Region
 
 from scipy.ndimage.morphology import distance_transform_edt
-from collections import defaultdict, Iterable
+from collections import defaultdict
 from nibabel import Nifti1Image
 from nilearn import image
 import pandas as pd

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -511,7 +511,21 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
         return Nifti1Image(result, affine)
 
     def get_colormap(self, region_specs: Iterable=None):
-        """Generate a matplotlib colormap from known rgb values of label indices."""
+        """
+        Generate a matplotlib colormap from known rgb values of label indices.
+        
+        The probability distribution is approximated from the region mask
+        based on the squared distance transform.
+
+        Parameters
+        ----------
+        region_specs: An iterable selection of regions
+            Optional parameter to only color the desired regions.
+
+        Return
+        ------
+        samples : PointSet in physcial coordinates corresponding to this parcellationmap.
+        """
         from matplotlib.colors import ListedColormap
         import numpy as np
 
@@ -527,11 +541,11 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
                     continue
                     
                 if (include_region_names is not None) and (regionname not in include_region_names):
-                    colors[index.label] = [0, 0, 0]
-                    
-                region = self.get_region(index=index)
-                if region.rgb is not None:
-                    colors[index.label] = region.rgb
+                    continue
+                else:
+                    region = self.get_region(index=index)
+                    if region.rgb is not None:
+                        colors[index.label] = region.rgb
 
         pallette = np.array(
             [

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from ..core.region import Region
 
 from scipy.ndimage.morphology import distance_transform_edt
-from collections import defaultdict
+from collections import defaultdict, Iterable
 from nibabel import Nifti1Image
 from nilearn import image
 import pandas as pd
@@ -510,20 +510,24 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
 
         return Nifti1Image(result, affine)
 
-    def get_colormap(self, region_specs : Iterable=None):
+    def get_colormap(self, region_specs: Iterable=None):
         """Generate a matplotlib colormap from known rgb values of label indices."""
         from matplotlib.colors import ListedColormap
         import numpy as np
 
         colors = {}
-        include_region_names = { self.parcellation.get_region(region_spec).name for region_spec in region_specs } if region_specs is not None else None
+        if region_specs is not None:
+            include_region_names = { self.parcellation.get_region(region_spec).name for region_spec in region_specs }
+        else:
+            include_region_names = None
+
         for regionname, indices in self._indices.items():
             for index in indices:
                 if index.label is None:
                     continue
                     
-                if include_region_names is not None and regionname not in include_region_names:
-                    colors[index.label] = [0, 0, 0] # black as default... potentially use a white default?
+                if (include_region_names is not None) and (regionname not in include_region_names):
+                    colors[index.label] = [0, 0, 0]
                     
                 region = self.get_region(index=index)
                 if region.rgb is not None:

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -510,7 +510,7 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
 
         return Nifti1Image(result, affine)
 
-    def get_colormap(self, region_spec=None):
+    def get_colormap(self, region_specs : Iterable=None):
         """Generate a matplotlib colormap from known rgb values of label indices."""
         from matplotlib.colors import ListedColormap
         import numpy as np

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -516,19 +516,18 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
         import numpy as np
 
         colors = {}
-        if region_spec is None:
-            for regionname, indices in self._indices.items():
-                for index in indices:
-                    if index.label is None:
-                        continue
-                    region = self.get_region(index=index)
-                    if region.rgb is not None:
-                        colors[index.label] = region.rgb
-        else:
-            region = self.parcellation.get_region(region_spec)
-            index = self._indices[region.name][0]
-            if region.rgb is not None:
-                colors[index.label] = region.rgb
+        include_region_names = { self.parcellation.get_region(region_spec).name for region_spec in region_specs } if region_specs is not None else None
+        for regionname, indices in self._indices.items():
+            for index in indices:
+                if index.label is None:
+                    continue
+                    
+                if include_region_names is not None and regionname not in include_region_names:
+                    colors[index.label] = [0, 0, 0] # black as default... potentially use a white default?
+                    
+                region = self.get_region(index=index)
+                if region.rgb is not None:
+                    colors[index.label] = region.rgb
 
         pallette = np.array(
             [

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -532,6 +532,28 @@ class Map(_concept.AtlasConcept, configuration_folder="maps"):
         ) / [255, 255, 255, 1]
         return ListedColormap(pallette)
 
+    def get_region_colormap(self, regionname):
+        """Generate a matplotlib colormap from known rgb values of label indices for a given region."""
+        from matplotlib.colors import ListedColormap
+        import numpy as np
+
+        colors = {}
+        indices = self._indices[regionname]
+        for index in indices:
+            if index.label is None:
+                continue
+            region = self.get_region(index=index)
+            if region.rgb is not None:
+                colors[index.label] = region.rgb
+
+        pallette = np.array(
+            [
+                list(colors[i]) + [1] if i in colors else [0, 0, 0, 0]
+                for i in range(max(colors.keys()) + 1)
+            ]
+        ) / [255, 255, 255, 1]
+        return ListedColormap(pallette)
+        
     def sample_locations(self, regionspec, numpoints: int):
         """ Sample 3D locations inside a given region.
 


### PR DESCRIPTION
Example code:
```python
import siibra
import numpy as np
from nilearn import plotting
m = siibra.get_map(parcellation="v2.9", space="MNI colin 27")
spec = m.regions[np.random.randint(0, len(m.regions) - 1)]
print(spec)
region_cmap = m.get_colormap(spec)
mesh = m.fetch(region=spec, format="mesh")
plotting.view_surf((mesh["verts"], mesh["faces"]), cmap=region_cmap )
```