### PR TITLE
chore: unify parcellationmap.fetch and sparsemap.fetch

### DIFF
--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -389,7 +389,7 @@ class Region(anytree.NodeMixin, concept.AtlasConcept):
                     self.name in m.regions
                 ]
             ):
-                result = m.fetch(index=m.get_index(self.name), format='image')
+                result = m.fetch(region=self, format='image')
                 if (maptype == MapType.STATISTICAL) and (threshold is not None):
                     logger.info(f"Thresholding statistical map at {threshold}")
                     result = Nifti1Image(

--- a/siibra/volumes/sparsemap.py
+++ b/siibra/volumes/sparsemap.py
@@ -21,11 +21,14 @@ from ..retrieval import cache
 
 from os import path
 import gzip
-from typing import Dict
+from typing import Dict, Union, TYPE_CHECKING
 from nilearn import image
 from nibabel import Nifti1Image, load
 from tqdm import tqdm
 import numpy as np
+
+if TYPE_CHECKING:
+    from ..core.region import Region
 
 
 class SparseIndex:
@@ -263,8 +266,10 @@ class SparseMap(parcellationmap.Map):
 
     def fetch(
         self,
-        index: MapIndex = None,
-        region: str = None,
+        region_or_index: Union[MapIndex, str, 'Region']=None,
+        *,
+        index: MapIndex=None,
+        region: Union[str, 'Region']=None,
         **kwargs
     ):
         """
@@ -273,39 +278,54 @@ class SparseMap(parcellationmap.Map):
 
         Arguments
         ---------
+        region_or_index: Union[str, Region, MapIndex]
+            Lazy match the specification.
         index : MapIndex
             The index to be fetched.
-        region: str
+        region: Union[str, Region]
             Region name specification. If given, will be used to
             decode the map index of a particular region.
         """
         if kwargs.get('format') in ['mesh'] + _volume.Volume.MESH_FORMATS:
             # a mesh is requested, this is not handled by the sparse map
-            return super().fetch(index=index, region=region, **kwargs)
+            return super().fetch(region_or_index, index=index, region=region, **kwargs)
 
-        if (index is not None) and (region is not None):
-            raise ValueError(
-                "'index' and 'region' must not be specifiec at the same "
-                f"time in {self.__class__.__name__}.fetch()"
-            )
+        try:
+            length = len([arg for arg in [region_or_index, region, index] if arg is not None])
+            assert length == 1
+        except AssertionError:
+            if length > 1:
+                raise parcellationmap.ExcessiveArgumentException(f"One and only one of region_or_index, region, index can be defined for fetch")
+            # user can provide no arguments, which assumes one and only one volume present
+
+        if isinstance(region_or_index, MapIndex):
+            index = region_or_index
+
+        from ..core.region import Region
+        if isinstance(region_or_index, (str, Region)):
+            region = region_or_index
+
+        volidx = None
         if index is not None:
             assert isinstance(index, MapIndex)
-            vol = index.volume
-        elif region is not None:
+            volidx = index.volume
+        if region is not None:
             index = self.get_index(region)
             assert index is not None
-            vol = index.volume
-        else:
-            if len(self) == 1:
-                vol = 0
-            else:
-                raise RuntimeError(
+            volidx = index.volume
+        
+        if volidx is None:
+            try:
+                assert len(self) == 1
+                volidx = 0
+            except AssertionError:
+                raise parcellationmap.InsufficientArgumentException(
                     f"{self.__class__.__name__} provides {len(self)} volumes. "
                     "Specify 'region' or 'index' for fetch() to identify one."
                 )
 
-        assert isinstance(vol, int)
-        x, y, z, v = self.sparse_index.mapped_voxels(vol)
+        assert isinstance(volidx, int)
+        x, y, z, v = self.sparse_index.mapped_voxels(volidx)
         result = np.zeros(self.shape, dtype=np.float32)
         result[x, y, z] = v
         return Nifti1Image(result, self.affine)


### PR DESCRIPTION
on discussion with @AhmetNSimsek 

parcellationmap.fetch and sparsemap.fetch had slightly different calling signatures. This PR fixes this, and unifies the call sigs. 

Also the fetch method has been slightly modified to allow str, Region (-> region) or mapindex (-> mapindex) to be supplied as positional argument. 

keywords argument remains functional.

e.g.

```python
index = MapIndex(0, 0)
region_str = "v2 left"
region = Region(*arg, **kwarg)

parcellationmap.fetch(region) 
parcellationmap.fetch(index) 
parcellationmap.fetch(region_str) 
parcellationmap.fetch(region=region) 
parcellationmap.fetch(region=region_str) 
parcellationmap.fetch(index=index)

```