### PR TITLE
chore: clarified+unified anchor.regions types

### DIFF
--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -621,7 +621,7 @@ class Species(Enum):
     UNSPECIFIED_SPECIES = 999
 
     @classmethod
-    def decode(cls, spec: Union[str, dict], fail_if_not_successful=True):
+    def decode(cls, spec: Union[str, 'Species', dict], fail_if_not_successful=True):
 
         MINDS_IDS = {
             "0ea4e6ba-2681-4f7d-9fa9-49b915caaac9": 1,

--- a/siibra/features/anchor.py
+++ b/siibra/features/anchor.py
@@ -24,7 +24,7 @@ from ..core.space import Space
 
 from ..vocabularies import REGION_ALIASES
 
-from typing import Union, List
+from typing import Union, List, Dict
 from enum import Enum
 
 
@@ -95,7 +95,9 @@ class AnatomicalAssignment:
     def invert(self):
         return AnatomicalAssignment(self.assigned_structure, self.query_structure, self.qualification.invert(), self.explanation)
 
-    def __lt__(self, other):
+    def __lt__(self, other: 'AnatomicalAssignment'):
+        if not isinstance(other, AnatomicalAssignment):
+            raise ValueError(f"Cannot compare AnatomicalAssignment with instances of '{type(other)}'")
         return self.qualification.value < other.qualification.value
 
 
@@ -106,7 +108,7 @@ class AnatomicalAnchor:
     or both.
     """
 
-    _MATCH_MEMO = {}
+    _MATCH_MEMO: Dict[str, Dict[Region, AssignmentQualification]] = {}
     _MASK_MEMO = {}
 
     def __init__(self, species: Union[List[Species], Species], location: Location = None, region: Union[str, Region] = None):
@@ -128,7 +130,7 @@ class AnatomicalAnchor:
         self._regions_cached = None
         self._regionspec = None
         if isinstance(region, Region):
-            self._regions_cached = [region]
+            self._regions_cached = { region: AssignmentQualification.EXACT }
         elif isinstance(region, str):
             self._regionspec = region
         else:
@@ -168,17 +170,17 @@ class AnatomicalAnchor:
         return len(self.region_aliases) > 0
 
     @property
-    def regions(self):
+    def regions(self) -> Dict[Region, AssignmentQualification]:
         # decoding region strings is quite compute intensive, so we cache this at the class level
         if self._regions_cached is None:
             if self._regionspec is None:
-                self._regions_cached = []
+                self._regions_cached = {}
             else:
                 if self._regionspec not in self.__class__._MATCH_MEMO:
-                    self._regions_cached = []
+                    self._regions_cached = {}
                     # decode the region specification into a set of region objects
                     regions = {
-                        r: AssignmentQualification['EXACT']
+                        r: AssignmentQualification.EXACT
                         for species in self.species
                         for r in Parcellation.find_regions(self._regionspec, species)
                     }

--- a/test/features/test_anchor.py
+++ b/test/features/test_anchor.py
@@ -1,0 +1,31 @@
+import pytest
+from siibra.core.region import Region
+from siibra.features.anchor import AnatomicalAnchor, Parcellation, Species
+from unittest.mock import patch
+
+@pytest.fixture
+def fixture_teardown():
+    yield ""
+    AnatomicalAnchor._MATCH_MEMO = {}
+
+region_specs = [
+    ("foo",fixture_teardown),
+    (Region("bar"),fixture_teardown),
+]
+
+@pytest.mark.parametrize("region,teardown", region_specs)
+def test_region_region_spec(region,teardown):
+    mock_found_regions = [Region("baz"), Region("hello world")]
+    species = Species.UNSPECIFIED_SPECIES
+    with patch.object(Parcellation, "find_regions", return_value=mock_found_regions) as mock_find_regions:
+        anchor = AnatomicalAnchor(species, region=region)
+        assert isinstance(anchor.regions, dict)
+        for _region in anchor.regions:
+            assert isinstance(_region, Region)
+        
+        if isinstance(region, Region):
+            mock_find_regions.assert_not_called()
+        elif isinstance(region, str):
+            mock_find_regions.assert_called_once_with(region, species)
+        else:
+            assert False, f"Cannot have region as neither str or Region"


### PR DESCRIPTION
currently, anchor.regions can have `List[Region]` or `Dict[Region, AssignmentQualification]` types.

this ambiguity can lend itself to errors in the future. 

This PR unifies the return type, and always returns `Dict[Region, AssignmentQualification]` type

