### PR TITLE
Temp fix to autodoc generation timeout problem

### DIFF
--- a/examples/03_data_features/000_matchings.py
+++ b/examples/03_data_features/000_matchings.py
@@ -119,20 +119,7 @@ for f in siibra.features.get(occ, "ebrains"):
 # ^^^^^^^^^^^^^^^^
 #
 # There are also data features which are linked to locations in a specific reference space.
-# For example, volumes of interest are tested for overlap with bounding boxes of regions.
-# The following dataset covering the hippocampus intersects with the mask of CA1.
-# Note how `siibra` deals with the fact that the volume of interest is defined in BigBrain space,
-# while the region is only mapped in the MNI spaces - it warps the bounding box
-# of the region to the space of the feature for the test.
-ca1 = siibra.get_region("julich 2.9", "ca1")
-features = siibra.features.get(ca1, siibra.features.VolumeOfInterest)
-print(features[0].name)
-print(features[0].last_match_description)
-
-
-# %%
-# Another example are gene expressions retrieved from the Allen atlas.
-# These are linked by the coordinate of their tissue probes in MNI space.
-# If a coordinate is inside the selected brain regions, it is an exact match.
+# For example, the gene expressions retrieved from the Allen atlas are linked by the coordinate
+# of their tissue probes in MNI space. If a coordinate is inside the selected brain regions, it is an exact match.
 features = siibra.features.get(v1, siibra.features.molecular.GeneExpressions, gene="TAC1")
 print(features[0].last_match_description)


### PR DESCRIPTION
Newly added voi features increase the doc generation time significantly. Removing voi-feature example from 03-000 to as a temporary fix to be able to produce docs.