### PR TITLE
Get connectivity features' resting-state paradigm from configs

### DIFF
--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -398,7 +398,7 @@ class Factory:
             kwargs["paradigm"] = spec.get("paradigm")
             return connectivity.FunctionalConnectivity(**kwargs)
         elif modality == "RestingState":
-            kwargs["paradigm"] = "RestingState"
+            kwargs["paradigm"] = spec.get("paradigm", "RestingState")
             return connectivity.FunctionalConnectivity(**kwargs)
         else:
             raise ValueError(f"Do not know how to build connectivity matrix of type {modality}.")


### PR DESCRIPTION
While the paradigm data is stored in the preconfigs, it was being replaced with the string "Resting State". The paradigm provides important information when it is provided, so this PR allows siibra to take it from the jsons.