### PR TITLE
feat: add ebrains ds to volumes

### DIFF
--- a/e2e/volumes/test_parcellationmap.py
+++ b/e2e/volumes/test_parcellationmap.py
@@ -21,3 +21,15 @@ def test_compress(siibramap: Map):
         not any(isinstance(vol, Subvolume) for vol in compressed_map.volumes),
         len(compressed_map.fragments) == 0,
     ])
+
+maps_have_volumes = [
+    siibra.get_map("2.9", "mni152", "statistical"),
+    siibra.get_map("2.9", "colin", "statistical"),
+]
+
+@pytest.mark.parametrize('siibramap', maps_have_volumes)
+def test_volume_have_datasets(siibramap: Map):
+    all_ds = [ds
+        for volume in siibramap.volumes
+        for ds in volume.datasets]
+    assert len(all_ds) > 0

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -249,6 +249,7 @@ class Factory:
             providers=providers,
             name=spec.get("name", {}),
             variant=spec.get("variant"),
+            datasets=cls.extract_datasets(spec),
         )
 
         return result

--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -20,9 +20,12 @@ from ..core import space
 
 import nibabel as nib
 from abc import ABC, abstractmethod
-from typing import List, Dict, Union, Set
+from typing import List, Dict, Union, Set, TYPE_CHECKING
 import json
 
+if TYPE_CHECKING:
+    from ..retrieval.datasets import EbrainsDataset
+    TypeDataset = EbrainsDataset
 
 class ColorVolumeNotSupported(NotImplementedError):
     pass
@@ -55,11 +58,13 @@ class Volume:
         providers: List['VolumeProvider'],
         name: str = "",
         variant: str = None,
+        datasets: List['TypeDataset'] = [],
     ):
         self._name_cached = name  # see lazy implementation below
         self._space_spec = space_spec
         self.variant = variant
         self._providers: Dict[str, 'VolumeProvider'] = {}
+        self.datasets = datasets
         for provider in providers:
             srctype = provider.srctype
             assert srctype not in self._providers


### PR DESCRIPTION
Some critical metadata (e.g. description of pmap of juelich brain regions) are currently been associated with volume (e.g. https://jugit.fz-juelich.de/t.dickscheid/brainscapes-configurations/-/blob/master/maps/colin27-jba29-continuous.json#L11-14) 

Currently, ebrains property on `Volume` is not utilized (only classes subclassing `Atlasconcept` correctly interprets dataset. since `Volume` does not, it does not properly interprets dataset)

This PR fixes this issue, and volume will now properly have dataset property. 