### PR TITLE
Merge meshes from all labels

### DIFF
--- a/siibra/volumes/neuroglancer.py
+++ b/siibra/volumes/neuroglancer.py
@@ -535,7 +535,7 @@ class NeuroglancerMesh(volume.VolumeProvider, srctype="neuroglancer/precompmesh"
     def fetch(self, label: int, fragment: str):
         """
         Fetches a particular mesh. Each mesh is a dictionary with keys:
-        
+
         Parameters
         ----------
         label: int
@@ -556,37 +556,59 @@ class NeuroglancerMesh(volume.VolumeProvider, srctype="neuroglancer/precompmesh"
             - 'name': Name of the of the mesh variant
         """
 
-        # extract fragment information for the requested mesh
-        fragment_infos = self._get_fragment_info(label)
-
-        if fragment is None:
-
-            # no fragment specified, return merged fragment meshes
-            if len(fragment_infos) == 1:
-                url, transform = next(iter(fragment_infos.values()))
-                return self._fetch_fragment(url, transform)
+        if label is None:
+            if hasattr(self, "parcellation_map"):
+                # providers of a parcellation map volume are monkey-patched
+                # with a reference to the map. In that case, we can infer
+                # the set of available labels, but it cannot be inferred
+                # from the neuroglancer URL only.
+                labels = self.parcellation_map.labels
             else:
-                logger.info(
-                    f"Fragments [{', '.join(fragment_infos.keys())}] are merged during fetch(). "
-                    "You can select one of them using the 'fragment' parameter."
-                )
-                return merge_meshes([self._fetch_fragment(u, t) for u, t in fragment_infos.values()])
-
+                raise RuntimeError(f"Fetching from {self.__class__.__name__} requires to specify a mesh label.")
         else:
+            labels = [label]
 
-            # match fragment to available fragments
-            matched = [
-                info for name, info in fragment_infos.items()
-                if fragment.lower() in name
-            ]
-            if len(matched) == 1:
-                url, transform = next(iter(matched))
-                return self._fetch_fragment(url, transform)
+        meshes = []
+        fragments = []
+        for label_i in labels:
+
+            # extract fragment information for the requested mesh
+            fragment_infos = self._get_fragment_info(label_i)
+            fragments.extend(fragment_infos.keys())
+
+            if fragment is None:
+                # no fragment specified, return merged fragment meshes
+                if len(fragment_infos) == 0:
+                    raise RuntimeError(f"Invalid label '{label_i}' for mesh fetching.")
+                else:
+                    for url, transform in fragment_infos.values():
+                        mesh = self._fetch_fragment(url, transform)
+                        mesh['labels'] = [label_i for _ in mesh['verts']]
+                        meshes.append(mesh)
+
             else:
-                raise ValueError(
-                    f"The requested mesh fragment name '{fragment}' could not be resolved. "
-                    f"Valid names are: {', '.join(fragment_infos.keys())}"
-                )
+                # match fragment to available fragments
+                matched = [
+                    info for name, info in fragment_infos.items()
+                    if fragment.lower() in name
+                ]
+                if len(matched) == 1:
+                    url, transform = next(iter(matched))
+                    mesh = self._fetch_fragment(url, transform)
+                    mesh['labels'] = [label_i for _v in mesh['verts']]
+                    meshes.append(mesh)
+                else:
+                    raise ValueError(
+                        f"The requested mesh fragment name '{fragment}' could not be resolved. "
+                        f"Valid names are: {', '.join(fragment_infos.keys())}"
+                    )
+
+        if len(fragments) > 1:
+            logger.info(
+                f"Fragments [{', '.join(fragments)}] were merged during fetch(). "
+                "You can select one of them using the 'fragment' parameter."
+            )
+        return merge_meshes(meshes)
 
 
 class NeuroglancerSurfaceMesh(NeuroglancerMesh, srctype="neuroglancer/precompmesh/surface"):

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -157,6 +157,9 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         self._parcellation_spec = parcellation_spec
         self._affine_cached = None
         for v in self.volumes:
+            # allow the providers to query their parcellation map if needed
+            for p in v._providers.values():
+                p.parcellation_map = self
             v._space_spec = space_spec
 
     @property

--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -79,7 +79,7 @@ class Volume:
         def concat(url: Union[str, Dict[str, str]], concat: str):
             if isinstance(url, str):
                 return url + concat
-            return { key: url[key] + concat for key in url }
+            return {key: url[key] + concat for key in url}
         return {
             srctype: concat(prov._url, f" {prov.label}" if hasattr(prov, "label") else "")
             for srctype, prov in self._providers.items()


### PR DESCRIPTION
If a neuroglancer mesh provider is linked to a parcellation map, and no label is given for fetching mesh fragments, collect them across all labels known in the parcellation instead of raising an error.