### PR TITLE
Find_indices now can utilise fragment

### DIFF
--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -231,12 +231,11 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                 for idx in self._indices[region]
             }
         regionname = region.name if isinstance(region, _region.Region) else region
+        matched_region_names = set(_.name for _ in (self.parcellation.find(regionname)))
+        matches = matched_region_names & self._indices.keys()
         if len(fragment) > 0:
             frag = fragment.removesuffix(" hemisphere")
-        matched_region_names = set(
-            _.name for _ in (self.parcellation.find(regionname + f" {frag}"))
-            )
-        matches = matched_region_names & self._indices.keys()
+            matches = [m for m in matches if frag.lower()in m.lower()]
         if len(matches) == 0:
             logger.warn(f"Region {regionname} not defined in {self}")
         return {


### PR DESCRIPTION
Solves inability to fetch maps when the parent region and the fragment are specified.
```python
import siibra
mp = siibra.get_map(parcellation="julich 2.9", space="colin 27")
mesh1 = mp.fetch(region="Area 5L (SPL) left", format="mesh")
mesh2 = mp.fetch(region="Area 5L (SPL)", format="mesh", fragment="left hemisphere")
```
Both meshes should be valid but `mesh2` fails to be fetched as `parcellationmap.get_index()` cannot decrease the matches [Area 5L (SPL) left, Area 5L (SPL) right] to Area 5L (SPL) left.