### PR TITLE
Fixes malformation of receptor density profiles due to trailing white spaces

### DIFF
--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -48,7 +48,7 @@ DECODERS = {
     ".json": lambda b: json.loads(b.decode()),
     ".tck": lambda b: streamlines.load(BytesIO(b)),
     ".csv": lambda b: pd.read_csv(BytesIO(b), delimiter=";"),
-    ".tsv": lambda b: pd.read_csv(BytesIO(b), delimiter="\t"),
+    ".tsv": lambda b: pd.read_csv(BytesIO(b), delimiter="\t").dropna(axis=0, how="all"),
     ".txt": lambda b: pd.read_csv(BytesIO(b), delimiter=" ", header=None),
     ".zip": lambda b: ZipFile(BytesIO(b)),
     ".png": lambda b: io.imread(BytesIO(b)),

--- a/test/features/test_receptors.py
+++ b/test/features/test_receptors.py
@@ -55,6 +55,10 @@ def test_get_region_receptor(region_spec: str):
     ]
     assert len(matched_features) > 0, f"expect at least one receptor query matching {region_spec}, but had none."
 
+profiles = siibra.features.molecular.ReceptorDensityProfile.get_instances()
+def test_receptor_density_profile_shape():
+    for f in profiles:
+        assert len(f.data.columns) == 1 and len(f.data.index) == 101
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Code to reproduce:
```python
import siibra
malformed_data = []
profiles = siibra.features.molecular.ReceptorDensityProfile.get_instances()
for i, f in enumerate(profiles):
    try:
         assert len(f.data.columns) == 1 and len(f.data.index) == 101
    except:
         malformed_data.append(f.)
         print(f"Malformed feature: {i} - {f}")
print(malformed_data)
```

This commit removes a row at the decoder level if all the columns are NA.