### PR TITLE
Fix fetch sparsemap request error

### DIFF
--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -71,7 +71,7 @@ class SiibraHttpRequestError(Exception):
 
     def __str__(self):
         return (
-            f"{self.msg}\n\tStatus code:{self.status_code:68.68}\n\tUrl:{self.response.url:76.76}"
+            f"{self.msg}\n\tStatus code: {self.status_code}\n\tUrl: {self.url:76.76}"
         )
 
 

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -412,7 +412,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         except requests.SiibraHttpRequestError as e:
             print(str(e))
 
-        if result is None:
+        if self.maptype is not MapType.STATISTICAL and result is None:
             raise RuntimeError(f"Error fetching {mapindex} from {self} as {kwargs.get('format', f'{self.formats}')}.")
         return result
 


### PR DESCRIPTION
`Sparsemap` has its own internal `logger.error` that notifies which volume will not be included and it will still return a map. But the `RuntimeError` at l:415 `parcellationmap`, breaks this. Example code to test:
```python
import siibra
m118 = siibra.get_map(parcellation="julich 1.18", space="ICBM 2009c Nonlinear", maptype="statistical")
m118.fetch(index=m118.get_index(region="Ch 4 (Basal Forebrain) - left"))
```
Expected output: nifti image with a few missing regions.
Returns: RuntimeError