### PR TITLE
When map.get_region takes MapIndex as only argument, it should raise exception

### DIFF
--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -253,6 +253,8 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         Region
             A region object defined in the parcellation map.
         """
+        if isinstance(label, MapIndex) and index is None:
+            raise TypeError(f"Specify MapIndex with index keyword.")
         if index is None:
             index = MapIndex(volume, label)
         matches = [


### PR DESCRIPTION
As of a6fdbc752286e073e8cc30511c94e214ce58a6b1

The user is not expected to know the `MapIndex` of a region, so `get_region` is used in tandem with `get_index`. Alternatively, one can directly set `label` and/or `volume`. This could be useful when going through a number of volumes/labels in a parcellation map, however, it is not deterministic since some maps are shipped with fragments additionally. So ideally a user should be able to use `get_region` in tandem with `get_index`:
```python
import siibra
mp = siibra.get_map(parcellation="julich 2.9", space="colin 27")
for regionname in mp.regions: 
    mp.get_region(
        mp.get_index(regionname)
    )
```
to obtain region objects. Currently, this code will fail because `index` is not specified within `get_region`.
With this PR, `get_region` raises an appropriate error. (Resulted from a prior "elevator" discussion with @dickscheid.)