### PR TITLE
Fixes the issue #327

### DIFF
--- a/siibra/features/connectivity/regional_connectivity.py
+++ b/siibra/features/connectivity/regional_connectivity.py
@@ -114,23 +114,26 @@ class RegionalConnectivity(Feature):
             A square matrix with region names as the column and row names.
         """
         assert len(self) > 0
-        if (subject is None) and (len(self) > 1):
-            # multiple matrices available, but no subject given - return mean matrix
-            logger.info(
-                f"No subject name supplied, returning mean connectivity across {len(self)} subjects. "
-                "You might alternatively specify an individual subject."
-            )
-            if "mean" not in self._matrices:
-                all_arrays = [
-                    self._connector.get(fname, decode_func=self._decode_func)
-                    for fname in siibra_tqdm(
-                        self._files.values(),
-                        total=len(self),
-                        desc=f"Averaging {len(self)} connectivity matrices"
-                    )
-                ]
-                self._matrices['mean'] = self._array_to_dataframe(np.stack(all_arrays).mean(0))
-            return self._matrices['mean']
+        if (subject is None) or (subject.lower() == "mean"):
+            if len(self) > 1:
+                logger.info(
+                    f"{'R' if subject else 'No subject name supplied, r'}eturning"
+                    " mean connectivity across {len(self)} subjects. "
+                    "You might alternatively specify an individual subject."
+                )
+                if "mean" not in self._matrices:
+                    all_arrays = [
+                        self._connector.get(fname, decode_func=self._decode_func)
+                        for fname in siibra_tqdm(
+                            self._files.values(),
+                            total=len(self),
+                            desc=f"Averaging {len(self)} connectivity matrices"
+                        )
+                    ]
+                    self._matrices['mean'] = self._array_to_dataframe(np.stack(all_arrays).mean(0))
+                return self._matrices['mean']
+            else:
+                logger.info("Only one subject is found. Returning the matrix.")
         if subject is None:
             subject = next(iter(self._files.keys()))
         if subject not in self._files:

--- a/siibra/features/tabular/regional_timeseries_activity.py
+++ b/siibra/features/tabular/regional_timeseries_activity.py
@@ -98,23 +98,26 @@ class RegionalTimeseriesActivity(tabular.Tabular):
             A table with region names as the column and timesteps as indices.
         """
         assert len(self) > 0
-        if (subject is None) and (len(self) > 1):
-            # multiple signal tables available, but no subject given - return mean table
-            logger.info(
-                f"No subject name supplied, returning mean signal table across {len(self)} subjects. "
-                "You might alternatively specify an individual subject."
-            )
-            if "mean" not in self._tables:
-                all_arrays = [
-                    self._connector.get(fname, decode_func=self._decode_func)
-                    for fname in siibra_tqdm(
-                        self._files.values(),
-                        total=len(self),
-                        desc=f"Averaging {len(self)} signal tables"
-                    )
-                ]
-                self._tables['mean'] = self._array_to_dataframe(np.stack(all_arrays).mean(0))
-            return self._tables['mean']
+        if (subject is None) or (subject.lower() == "mean"):
+            if len(self) > 1:
+                logger.info(
+                    f"{'R' if subject else 'No subject name supplied, r'}eturning"
+                    " mean activity table across {len(self)} subjects. "
+                    "You might alternatively specify an individual subject."
+                )
+                if "mean" not in self._tables:
+                    all_arrays = [
+                        self._connector.get(fname, decode_func=self._decode_func)
+                        for fname in siibra_tqdm(
+                            self._files.values(),
+                            total=len(self),
+                            desc=f"Averaging {len(self)} signal tables"
+                        )
+                    ]
+                    self._tables['mean'] = self._array_to_dataframe(np.stack(all_arrays).mean(0))
+                return self._tables['mean']
+            else:
+                logger.info("Only one subject is found. Returning the table.")
         if subject is None:
             subject = next(iter(self._files.keys()))
         if subject not in self._files:


### PR DESCRIPTION
Proper digestion of "mean" as input to `RegionalConnvetivity.get_matrix()` and `RegionalTimeseriesActivity.get_table()` and appropriate log info.
Added another info for when there is only one subject/file is available in the dataset.