### PR TITLE
Improve sparse map handling

### DIFF
--- a/config_schema/siibra/map/v0.0.1.json
+++ b/config_schema/siibra/map/v0.0.1.json
@@ -11,9 +11,18 @@
             "$ref": "config_schema/at_id.json"
         },
         "sparsemap": {
-            "is_sparsemap": "bool",
-            "cached": "bool",
-            "url": "string"
+            "type": "object",
+            "properties": {
+                "is_sparsemap": {
+                    "type": "boolean"
+                },
+                "cached": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
         },
         "volumes": {
             "type": "array",

--- a/config_schema/siibra/map/v0.0.1.json
+++ b/config_schema/siibra/map/v0.0.1.json
@@ -10,6 +10,11 @@
         "parcellation": {
             "$ref": "config_schema/at_id.json"
         },
+        "sparsemap": {
+            "is_sparsemap": "bool",
+            "cached": "bool",
+            "url": "string"
+        },
         "volumes": {
             "type": "array",
             "items": {

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -269,7 +269,7 @@ class Factory:
         identifier = f"{spec['@type'].replace('/','-')}_{basename}"
         volumes = cls.extract_volumes(spec)
 
-        if ("sparsemap" in spec) and spec.get("sparsemap")["is_sparsemap"]:
+        if ("sparsemap" in spec) and spec.get("sparsemap").get("is_sparsemap"):
             Maptype = sparsemap.SparseMap
             return Maptype(
                 identifier=spec.get("@id", identifier),
@@ -290,7 +290,7 @@ class Factory:
         Maptype = parcellationmap.Map
         if len(volumes) > MIN_VOLUMES_FOR_SPARSE_MAP:
             logger.debug(
-                f"Using sparse map for {spec['filename']} to code its "
+                f"Using sparse map for {spec.get('filename')} to code its "
                 f"{len(volumes)} volumes efficiently."
             )
             Maptype = sparsemap.SparseMap
@@ -302,7 +302,7 @@ class Factory:
             ) + 1
             if max_z > MIN_VOLUMES_FOR_SPARSE_MAP:
                 logger.debug(
-                    f"Using sparse map for {spec['filename']} to code its "
+                    f"Using sparse map for {spec.get('filename')} to code its "
                     f"{max_z} z levels efficiently."
                 )
                 Maptype = sparsemap.SparseMap

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -269,10 +269,29 @@ class Factory:
         identifier = f"{spec['@type'].replace('/','-')}_{basename}"
         volumes = cls.extract_volumes(spec)
 
+        if ("sparsemap" in spec) and spec.get("sparsemap")["is_sparsemap"]:
+            Maptype = sparsemap.SparseMap
+            return Maptype(
+                identifier=spec.get("@id", identifier),
+                name=spec.get("name", name),
+                space_spec=spec.get("space", {}),
+                parcellation_spec=spec.get("parcellation", {}),
+                indices=spec.get("indices", {}),
+                volumes=volumes,
+                shortname=spec.get("shortName", ""),
+                description=spec.get("description"),
+                modality=spec.get("modality"),
+                publications=spec.get("publications", []),
+                datasets=cls.extract_datasets(spec),
+                is_cached=spec.get("sparsemap").get("cached", False),
+                cache_url=spec.get("sparsemap").get("url", "")
+            )
+
         Maptype = parcellationmap.Map
         if len(volumes) > MIN_VOLUMES_FOR_SPARSE_MAP:
             logger.debug(
-                f"Using sparse map for {spec['filename']} to code its {len(volumes)} volumes efficiently."
+                f"Using sparse map for {spec['filename']} to code its "
+                f"{len(volumes)} volumes efficiently."
             )
             Maptype = sparsemap.SparseMap
         else:
@@ -283,7 +302,8 @@ class Factory:
             ) + 1
             if max_z > MIN_VOLUMES_FOR_SPARSE_MAP:
                 logger.debug(
-                    f"Using sparse map for {spec['filename']} to code its {max_z} z levels efficiently."
+                    f"Using sparse map for {spec['filename']} to code its "
+                    f"{max_z} z levels efficiently."
                 )
                 Maptype = sparsemap.SparseMap
 

--- a/siibra/retrieval/repositories.py
+++ b/siibra/retrieval/repositories.py
@@ -319,6 +319,10 @@ class ZipfileConnector(RepositoryConnector):
     def __eq__(self, other):
         return self.url == other.url
 
+    def clear_cache(self):
+        os.remove(self.zipfile)
+        self._zipfile_cached = None
+
     class FileLoader:
         """
         Loads a file from the zip archive, but mimics the behaviour
@@ -328,8 +332,12 @@ class ZipfileConnector(RepositoryConnector):
             self.zipfile = zipfile
             self.filename = filename
             self.func = decode_func
-            self.cached = True
+            self.cachefile = CACHE.build_filename(zipfile+filename)
 
+        @property
+        def cached(self):
+            return os.path.isfile(self.cachefile)
+        
         @property
         def data(self):
             container = ZipFile(self.zipfile)

--- a/siibra/retrieval/repositories.py
+++ b/siibra/retrieval/repositories.py
@@ -323,7 +323,7 @@ class ZipfileConnector(RepositoryConnector):
         os.remove(self.zipfile)
         self._zipfile_cached = None
 
-    class FileLoader:
+    class ZipFileLoader:
         """
         Loads a file from the zip archive, but mimics the behaviour
         of cached http requests used in other connectors.
@@ -347,9 +347,9 @@ class ZipfileConnector(RepositoryConnector):
         """Get a lazy loader for a file, for loading data
         only once loader.data is accessed."""
         if decode_func is None:
-            return self.FileLoader(self.zipfile, filename, lambda b: self._decode_response(b, filename))
+            return self.ZipFileLoader(self.zipfile, filename, lambda b: self._decode_response(b, filename))
         else:
-            return self.FileLoader(self.zipfile, filename, decode_func)
+            return self.ZipFileLoader(self.zipfile, filename, decode_func)
 
     def __str__(self):
         return f"{self.__class__.__name__}: {self.zipfile}"

--- a/siibra/retrieval/repositories.py
+++ b/siibra/retrieval/repositories.py
@@ -205,7 +205,7 @@ class GitlabConnector(RepositoryConnector):
                 self._tag_checked = True
             except Exception as e:
                 print(str(e))
-                print("Could not connect to gitlab server!")
+                logger.warning("Could not connect to gitlab server!")
         return self._want_commit_cached
 
     @property

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -179,6 +179,8 @@ class HttpRequest:
                     f.write(data)
             if size_bytes > min_bytesize_with_no_progress_info:
                 progress_bar.close()
+            if self.refresh and os.path.isfile(self.cachefile):
+                os.remove(self.cachefile)
             self.refresh = False
             os.rename(temp_cachefile, self.cachefile)
             

--- a/siibra/volumes/sparsemap.py
+++ b/siibra/volumes/sparsemap.py
@@ -245,7 +245,10 @@ class SparseMap(parcellationmap.Map):
         )
         self._sparse_index_cached = None
         self._sparseindex_zip_url = cache_url if is_cached else ""
-        self._cache_prefix = f"{self.parcellation.id}_{self.space.id}_{self.maptype}_{name}_index"
+    
+    @property
+    def _cache_prefix(self):
+        return f"{self.parcellation.id}_{self.space.id}_{self.maptype}_{self.name}_index"
 
     @property
     def sparse_index(self):

--- a/siibra/volumes/sparsemap.py
+++ b/siibra/volumes/sparsemap.py
@@ -259,16 +259,17 @@ class SparseMap(parcellationmap.Map):
                 try:
                     spind = self.load_zipped_sparseindex(self._sparseindex_zip_url)
                 except Exception as e:
-                    logger.debug("Could not load SparseIndex from precomputed source:\n", e)
+                    logger.debug("Could not load SparseIndex from precomputed source:\n", exc_info=1)
             if spind is None:
                 logger.debug("Loading SparseIndex from Gitlab.")
                 gconn = GitlabConnector(self._GITLAB_SERVER, self._GITLAB_PROJECT, "main")
                 zip_fname = f"{self.name.replace(' ', '_')}_index.zip"
                 try:
+                    assert zip_fname in gconn.search_files(), f"{zip_fname} is not in {gconn}."
                     zipfile = gconn.get_loader(zip_fname).url
                     spind = self.load_zipped_sparseindex(zipfile)
                 except Exception as e:
-                    logger.debug("Could not load SparseIndex from Gitlab:\n", e)
+                    logger.debug("Could not load SparseIndex from Gitlab:\n", exc_info=1)
             if spind is None:
                 with _volume.SubvolumeProvider.UseCaching():
                     spind = SparseIndex()

--- a/siibra/volumes/sparsemap.py
+++ b/siibra/volumes/sparsemap.py
@@ -255,16 +255,18 @@ class SparseMap(parcellationmap.Map):
         if self._sparse_index_cached is None:
             spind = SparseIndex._from_cache(self._cache_prefix)
             if spind is None and len(self._sparseindex_zip_url) > 0:
+                logger.debug("Loading SparseIndex from precomputed source.")
                 try:
-                    logger.debug("Loading SparseIndex from precomputed source.")
                     spind = self.load_zipped_sparseindex(self._sparseindex_zip_url)
                 except Exception as e:
                     logger.debug("Could not load SparseIndex from precomputed source:\n", e)
             if spind is None:
+                logger.debug("Loading SparseIndex from Gitlab.")
+                gconn = GitlabConnector(self._GITLAB_SERVER, self._GITLAB_PROJECT, "main")
+                zip_fname = f"{self.name.replace(' ', '_')}_index.zip"
                 try:
-                    logger.debug("Loading SparseIndex from Gitlab.")
-                    gconn = GitlabConnector(self._GITLAB_SERVER, self._GITLAB_PROJECT, "main")
-                    zipfile = gconn.get(f"{self.name.replace(' ', '_')}_index.zip")
+                    assert zip_fname in gconn.search_files(suffix=".zip"), f"could not find {zip_fname} in the repository."
+                    zipfile = gconn.get(zip_fname)
                     spind = self.load_zipped_sparseindex(zipfile)
                 except Exception as e:
                     logger.debug("Could not load SparseIndex from Gitlab:\n", e)

--- a/test/volumes/test_sparsemap.py
+++ b/test/volumes/test_sparsemap.py
@@ -14,8 +14,8 @@ class DCls:
 
 
 @pytest.fixture
-def mock_sparse_index_from_cache():
-    with patch.object(SparseIndex, '_from_cache') as mock:
+def mock_sparse_index_from_local_cache():
+    with patch.object(SparseIndex, '_from_local_cache') as mock:
         yield mock
 
 @pytest.fixture
@@ -34,8 +34,8 @@ def mock_map_fetch():
         yield mock
 
 @pytest.fixture
-def mock_sparse_index_to_cache():
-    with patch.object(SparseIndex, '_to_cache') as mock:
+def mock_sparse_index_to_local_cache():
+    with patch.object(SparseIndex, '_to_local_cache') as mock:
         yield mock
 
 @pytest.fixture
@@ -57,8 +57,8 @@ def sparse_map_inst():
 
 
 @pytest.fixture
-def test_sparse_idx_mocks(sparse_map_inst, mock_sparse_map_spc_parc, mock_sparse_index_from_cache, mock_map_fetch, mock_sparse_index_to_cache, mock_sparse_index_add_img):
-    yield (sparse_map_inst, *mock_sparse_map_spc_parc, mock_sparse_index_from_cache, mock_map_fetch, mock_sparse_index_to_cache, mock_sparse_index_add_img)
+def test_sparse_idx_mocks(sparse_map_inst, mock_sparse_map_spc_parc, mock_sparse_index_from_local_cache, mock_map_fetch, mock_sparse_index_to_local_cache, mock_sparse_index_add_img):
+    yield (sparse_map_inst, *mock_sparse_map_spc_parc, mock_sparse_index_from_local_cache, mock_map_fetch, mock_sparse_index_to_local_cache, mock_sparse_index_add_img)
 
 @pytest.mark.parametrize('test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag',
                          product(
@@ -68,7 +68,7 @@ def test_sparse_idx_mocks(sparse_map_inst, mock_sparse_map_spc_parc, mock_sparse
                          ),
                          indirect=["test_sparse_idx_mocks"])
 def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
-    sparse_map_inst, spc_mock, parc_mock, mock_sparse_index_from_cache, mock_map_fetch, mock_sparse_index_to_cache, mock_sparse_index_add_img = test_sparse_idx_mocks
+    sparse_map_inst, spc_mock, parc_mock, mock_sparse_index_from_local_cache, mock_map_fetch, mock_sparse_index_to_local_cache, mock_sparse_index_add_img = test_sparse_idx_mocks
     assert isinstance(sparse_map_inst, SparseMap)
 
     mock_map_fetch.return_value = DCls(hello="world")
@@ -79,9 +79,9 @@ def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
         sparse_map_inst._sparse_index_cached = None
     
     if disk_cached_flag:
-        mock_sparse_index_from_cache.return_value = DCls(boo="baz", probs=[1,2], max=lambda: 1)
+        mock_sparse_index_from_local_cache.return_value = DCls(boo="baz", probs=[1,2], max=lambda: 1)
     else:
-        mock_sparse_index_from_cache.return_value = None
+        mock_sparse_index_from_local_cache.return_value = None
     spc_mock.return_value = DCls(id='hello world spc')
     parc_mock.return_value = DCls(id='hello world parc')
 
@@ -94,15 +94,15 @@ def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
                 if mem_cache_flag or disk_cached_flag:
                     sparse_index = sparse_map_inst.sparse_index
                     if mem_cache_flag:
-                        mock_sparse_index_from_cache.assert_not_called()
+                        mock_sparse_index_from_local_cache.assert_not_called()
                         mock_map_fetch.assert_not_called()
-                        mock_sparse_index_to_cache.assert_not_called()
+                        mock_sparse_index_to_local_cache.assert_not_called()
                         mock_sparse_index_add_img.assert_not_called()
                         return
                     if disk_cached_flag:
-                        mock_sparse_index_from_cache.assert_called_once()
+                        mock_sparse_index_from_local_cache.assert_called_once()
                         mock_map_fetch.assert_not_called()
-                        mock_sparse_index_to_cache.assert_not_called()
+                        mock_sparse_index_to_local_cache.assert_not_called()
                         mock_sparse_index_add_img.assert_not_called()
                         return
             
@@ -112,15 +112,15 @@ def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
                     # TODO since new spind is created at runtime, not too sure how to bypass this assertion error
                     pass
                 finally:
-                    mock_sparse_index_from_cache.assert_called_once()
+                    mock_sparse_index_from_local_cache.assert_called_once()
                     mock_map_fetch.assert_called()
                     mock_sparse_index_add_img.assert_called()
-                    mock_sparse_index_to_cache.assert_called_once()
+                    mock_sparse_index_to_local_cache.assert_called_once()
 
 
-def test_sparse_index_prefixes(mock_sparse_map_spc_parc, mock_sparse_index_from_cache):
+def test_sparse_index_prefixes(mock_sparse_map_spc_parc, mock_sparse_index_from_local_cache):
     spc_mock, parc_mock = mock_sparse_map_spc_parc
-    mock_sparse_index_from_cache.return_value = DCls(probs=[1,2,3], max=lambda:2)
+    mock_sparse_index_from_local_cache.return_value = DCls(probs=[1,2,3], max=lambda:2)
 
     spc_mock.return_value = DCls(id='hello world spc')
     parc_mock.return_value = DCls(id='hello world parc')
@@ -147,7 +147,7 @@ def test_sparse_index_prefixes(mock_sparse_map_spc_parc, mock_sparse_index_from_
             foo.sparse_index
             bar.sparse_index
 
-            call0, call1 = mock_sparse_index_from_cache.call_args_list
+            call0, call1 = mock_sparse_index_from_local_cache.call_args_list
             
             assert call0 != call1, f"Prefix used should be different, based on not just space, parcellation, maptype, but also name"
             assert foo._cache_prefix != bar._cache_prefix

--- a/test/volumes/test_sparsemap.py
+++ b/test/volumes/test_sparsemap.py
@@ -15,7 +15,7 @@ class DCls:
 
 @pytest.fixture
 def mock_sparse_index_from_cache():
-    with patch.object(SparseIndex, 'from_cache') as mock:
+    with patch.object(SparseIndex, '_from_cache') as mock:
         yield mock
 
 @pytest.fixture
@@ -33,10 +33,9 @@ def mock_map_fetch():
     with patch('siibra.volumes.parcellationmap.Map.fetch') as mock:
         yield mock
 
-
 @pytest.fixture
-def mock_parse_index_to_cache():
-    with patch.object(SparseIndex, 'to_cache') as mock:
+def mock_sparse_index_to_cache():
+    with patch.object(SparseIndex, '_to_cache') as mock:
         yield mock
 
 @pytest.fixture
@@ -58,8 +57,8 @@ def sparse_map_inst():
 
 
 @pytest.fixture
-def test_sparse_idx_mocks(sparse_map_inst, mock_sparse_map_spc_parc,mock_sparse_index_from_cache, mock_map_fetch, mock_parse_index_to_cache, mock_sparse_index_add_img):
-    yield (sparse_map_inst, *mock_sparse_map_spc_parc, mock_sparse_index_from_cache, mock_map_fetch, mock_parse_index_to_cache, mock_sparse_index_add_img)
+def test_sparse_idx_mocks(sparse_map_inst, mock_sparse_map_spc_parc, mock_sparse_index_from_cache, mock_map_fetch, mock_sparse_index_to_cache, mock_sparse_index_add_img):
+    yield (sparse_map_inst, *mock_sparse_map_spc_parc, mock_sparse_index_from_cache, mock_map_fetch, mock_sparse_index_to_cache, mock_sparse_index_add_img)
 
 @pytest.mark.parametrize('test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag',
                          product(
@@ -69,7 +68,7 @@ def test_sparse_idx_mocks(sparse_map_inst, mock_sparse_map_spc_parc,mock_sparse_
                          ),
                          indirect=["test_sparse_idx_mocks"])
 def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
-    sparse_map_inst, spc_mock, parc_mock, mock_sparse_index_from_cache, mock_map_fetch, mock_parse_index_to_cache, mock_sparse_index_add_img = test_sparse_idx_mocks
+    sparse_map_inst, spc_mock, parc_mock, mock_sparse_index_from_cache, mock_map_fetch, mock_sparse_index_to_cache, mock_sparse_index_add_img = test_sparse_idx_mocks
     assert isinstance(sparse_map_inst, SparseMap)
 
     mock_map_fetch.return_value = DCls(hello="world")
@@ -97,13 +96,13 @@ def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
                     if mem_cache_flag:
                         mock_sparse_index_from_cache.assert_not_called()
                         mock_map_fetch.assert_not_called()
-                        mock_parse_index_to_cache.assert_not_called()
+                        mock_sparse_index_to_cache.assert_not_called()
                         mock_sparse_index_add_img.assert_not_called()
                         return
                     if disk_cached_flag:
                         mock_sparse_index_from_cache.assert_called_once()
                         mock_map_fetch.assert_not_called()
-                        mock_parse_index_to_cache.assert_not_called()
+                        mock_sparse_index_to_cache.assert_not_called()
                         mock_sparse_index_add_img.assert_not_called()
                         return
             
@@ -116,7 +115,7 @@ def test_sparse_index(test_sparse_idx_mocks,mem_cache_flag,disk_cached_flag):
                     mock_sparse_index_from_cache.assert_called_once()
                     mock_map_fetch.assert_called()
                     mock_sparse_index_add_img.assert_called()
-                    mock_parse_index_to_cache.assert_called_once()
+                    mock_sparse_index_to_cache.assert_called_once()
 
 
 def test_sparse_index_prefixes(mock_sparse_map_spc_parc, mock_sparse_index_from_cache):

--- a/test/volumes/test_sparsemap.py
+++ b/test/volumes/test_sparsemap.py
@@ -150,3 +150,4 @@ def test_sparse_index_prefixes(mock_sparse_map_spc_parc, mock_sparse_index_from_
             call0, call1 = mock_sparse_index_from_cache.call_args_list
             
             assert call0 != call1, f"Prefix used should be different, based on not just space, parcellation, maptype, but also name"
+            assert foo._cache_prefix != bar._cache_prefix


### PR DESCRIPTION
This PR introduces:
- Allow a clear definition for a SparseMap from the configuration.
     - Legacy method is preserved
-  Allows fetching SparseIndex of a SparseMap from a precomputed SparseIndex in a zip file.

Connected config branch: https://jugit.fz-juelich.de/t.dickscheid/brainscapes-configurations/-/tree/clarifySparsemaps

This decreases the required time it takes to fetch any map from SparseMaps as the SparseIndex is no longer required to be calculated on the fly.
No functionality is removed, so if a SparseMaps does not have stored SparseIndex or the zip file is unreachable, then the Index is calculated as before.

See related issue #334