### PR TITLE
InstanceDataframe for maps (strictly additive, does not remove InstanceTable)

### DIFF
--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -28,6 +28,7 @@ from .core import (
     parcellation as _parcellation,
     space as _space
 )
+from .volumes import parcellationmap as _parcellationmap
 from .retrieval.requests import (
     EbrainsRequest as _EbrainsRequest,
     CACHE as cache
@@ -59,6 +60,8 @@ def __getattr__(attr: str):
         return _space.Space.registry()
     elif attr == 'parcellations':
         return _parcellation.Parcellation.registry()
+    elif attr == 'maps':
+        return _parcellationmap.Map.registry()
     elif attr == 'use_configuration':
         return configuration.Configuration.use_configuration
     elif attr == 'extend_configuration':

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -231,39 +231,8 @@ class InstanceTable(Generic[T], Iterable):
                             for attribute in ['parcellation', 'space', 'maptype']
                         }
                     )
-            self._dataframe_cached = self.InstanceDataframe(self._elements, attrs)
+            self._dataframe_cached = pd.DataFrame(index=list(self._elements.keys()), data=attrs)
         return self._dataframe_cached
-
-    class InstanceDataframe(pd.DataFrame):
-
-        def __init__(self, objs: dict, attrs: list):
-            pd.DataFrame.__init__(self, data=attrs, index=list(objs.keys()))
-            import warnings
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=UserWarning)
-                self._objs = objs
-
-        def __dir__(self):
-            # make autocompletion work on the row names
-            return list(self.index)
-
-        def __getattr__(self, attr):
-            # make the row name return the corresponding object
-            if attr in self.index:
-                return self._objs[attr]
-            return super().__getattr__(attr)
-
-        def query(self, expr: str):
-            # allow to build a filtered instance table
-            df = pd.DataFrame.query(self, expr, inplace=False)
-            return self.__class__(
-                objs={
-                    k: v for k, v in self._objs.items()
-                    if k in df.index
-                },
-                attrs=list(dict(df.T).values())
-            )
-
 
 class LoggingContext:
     def __init__(self, level):

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -90,7 +90,7 @@ class InstanceTable(Generic[T], Iterable):
 
     def __dir__(self) -> Iterable[str]:
         """List of all object keys in the registry"""
-        return self._elements.keys()
+        return ["dataframe"] + list(self._elements.keys())
 
     def __str__(self) -> str:
         if len(self) > 0:
@@ -221,19 +221,19 @@ class InstanceTable(Generic[T], Iterable):
     def dataframe(self):
         if self._dataframe_cached is None:
             values = self._elements.values()
-            attrs = [{'name': m.name, 'species': str(m.species)} for m in values]
-            attribute_keys = ['parcellation', 'space', 'maptype']
-            for attribute in attribute_keys:
-                for i, m in enumerate(values):
-                    if hasattr(m, attribute):
-                        attrs[i].update(
-                            {attribute: m.__getattribute__(attribute).name}
-                        )
-            self._dataframe_cached = self.InstanceDataframe(
-                objs=self._elements,
-                attrs=attrs
-            )
+            attrs = []
+            for i, val in enumerate(values):
+                attrs.append({'name': val.name, 'species': str(val.species)})
+                if hasattr(val, 'maptype'):
+                    attrs[i].update(
+                        {
+                            attribute: val.__getattribute__(attribute).name
+                            for attribute in ['parcellation', 'space', 'maptype']
+                        }
+                    )
+            self._dataframe_cached = self.InstanceDataframe(self._elements, attrs)
         return self._dataframe_cached
+
     class InstanceDataframe(pd.DataFrame):
 
         def __init__(self, objs: dict, attrs: list):

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -217,7 +217,8 @@ class InstanceTable(Generic[T], Iterable):
                     hint = f"Did you mean {' or '.join(closest)}?"
             raise AttributeError(f"Term '{index}' not in {__class__.__name__}. " + hint)
 
-    def get_dataframe(self):
+    @property
+    def dataframe(self):
         if self._dataframe_cached is None:
             values = self._elements.values()
             attrs = [{'name': m.name, 'species': str(m.species)} for m in values]

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -19,7 +19,6 @@ from .. import logger, QUIET
 from ..commons import (
     MapIndex,
     MapType,
-    InstanceDataframe,
     compare_maps,
     iterate_connected_components,
     clear_name,
@@ -169,39 +168,6 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         if self._species_cached is None:
             self._species_cached = self.space.species
         return self.space._species_cached
-
-    @classmethod
-    def registry(cls) -> InstanceDataframe:
-        if cls._configuration_folder is None:
-            return None
-        if cls._registry_cached is None:
-            from ..configuration import Configuration
-            conf = Configuration()
-            # visit the configuration to provide a cleanup function
-            # in case the user changes the configuration during runtime.
-            Configuration.register_cleanup(cls.clear_registry)
-            assert cls._configuration_folder in conf.folders
-            objects = conf.build_objects(cls._configuration_folder)
-            logger.debug(f"Built {len(objects)} preconfigured {cls.__name__} objects.")
-            assert len(objects) > 0
-            assert all([hasattr(o, 'key') for o in objects])
-            if len({o.__class__ for o in objects}) > 1:
-                logger.warning(f"{cls.__name__} registry contains multiple classes: {', '.join(list({o.__class__.__name__ for o in objects}))}")
-            assert hasattr(objects[0].__class__, "match") and callable(objects[0].__class__.match)
-            cls._registry_cached = InstanceDataframe(
-                objs={m.key: m for m in objects},
-                attrs=[
-                    {
-                        'name': m.name, 
-                        'species': str(m.species),
-                        'parcellation': m.parcellation.name,
-                        'space': m.space.name,
-                        'maptype': m.maptype.name.lower()
-                    }
-                    for m in objects
-                ]
-            )
-        return cls._registry_cached
 
     def get_index(self, region: Union[str, "Region"]):
         """


### PR DESCRIPTION
This PR adds an instance table in the form of a data frame for maps (#329). It is strictly additive and does not remove any existing functionality for the other instance tables of class `InstanceTable`.
While more discussion and additions could be had, this is a highly requested feature. Therefore, IMO we should add it as is and continue discussing the remainder under a new issue.
(`InstanceDataframe` could be expanded with similar functionalities of `InstanceTable`, however, for the time bein the goal is to provide an overview. Also, `query` provides a lot of functionalites.)
Usage:
```python
import siibra
print(siibra.maps.head())
print(siibra.maps.columns)
print(siibra.maps.index)
siibra.maps.query("space == 'MNI Colin 27'")
```