### PR TITLE
Fix doc failure due to setuptools

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+
+# Set the version of Python and other tools you might need
+build:
+   os: ubuntu-22.04
+   tools:
+      python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
@@ -15,9 +22,8 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.8"
    install:
-   - requirements: docs/requirements-doc.txt
-   - method: pip
-     path: .
-   system_packages: true   
+      - requirements: docs/requirements-doc.txt
+      - method: pip
+        path: .
+   system_packages: true

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,3 +1,4 @@
+setuptools >= 67.7.2
 -r ../requirements.txt
 memory-profiler
 ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ nibabel
 appdirs
 scikit-image
 requests
-memoization
 neuroglancer-scripts
 nilearn
 typing-extensions; python_version < "3.8"


### PR DESCRIPTION
Readthedocs change the setuptools version they use which in turn causes a few cyclical issues. Using setuptools>=67.7.2 in doc requirements solves the first issue. Then, this produces https://github.com/readthedocs/readthedocs.org/issues/10290. And this can be solved by using ubuntu 22-04 for venv used in doc creation.

Additionally, memoization is no longer used, so it is removed.