### PR TITLE
Point assignments also have map value

### DIFF
--- a/e2e/volumes/test_parcellationmap.py
+++ b/e2e/volumes/test_parcellationmap.py
@@ -46,13 +46,25 @@ containedness = [
             maptype="statistical"
         ),
         '`input containedness` >= 0.5'
+    ),
+    (
+        siibra.Point((27.75, -32.0, 63.725), space='mni152', sigma_mm=0.),
+        siibra.get_map(
+            parcellation="julich 2.9",
+            space="mni152",
+            maptype="statistical"
+        ),
+        '`map value` == None'
     )
 ]
 
 @pytest.mark.parametrize('point,map,query', containedness)
-def test_containedness(point,map:Map,query):
+def test_containedness(point, map:Map, query):
     assignments = map.assign(point)
-    assert len(assignments.query(query)) > 0
+    if point.sigma > 0:
+        assert len(assignments.query(query)) > 0
+    if point.sigma == 0:
+        assert len(assignments.query(query)) == 0
 
 # TODO: when merging neuroglancer/precomputed is supported, add to the list
 maps_w_fragments = product(

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -910,7 +910,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                     **{
                         "correlation": None,
                         "intersection over union": None,
-                        "map value": None,
+                        "map value": a.map_value,
                         "map weighted mean": None,
                         "map containedness": None,
                         "input weighted mean": None,


### PR DESCRIPTION
During implementation of dataclass for assignments, the 'map value' was forgotten to be assigned for points. Fixes
https://github.com/FZJ-INM1-BDA/siibra-python/issues/338