### PR TITLE
Detect csv delimiter with Python’s builtin sniffer tool

### DIFF
--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -52,7 +52,7 @@ DECODERS = {
     ".gii": lambda b: GiftiImage.from_bytes(b),
     ".json": lambda b: json.loads(b.decode()),
     ".tck": lambda b: streamlines.load(BytesIO(b)),
-    ".csv": lambda b: pd.read_csv(BytesIO(b), delimiter=";"),
+    ".csv": lambda b: pd.read_csv(BytesIO(b)),
     ".tsv": lambda b: pd.read_csv(BytesIO(b), delimiter="\t").dropna(axis=0, how="all"),
     ".txt": lambda b: pd.read_csv(BytesIO(b), delimiter=" ", header=None),
     ".zip": lambda b: ZipFile(BytesIO(b)),


### PR DESCRIPTION
The use of ";" as the default csv decoder delimiter appears to be originally written to parse 1000 brains data. However, now this is resolved in `decoder` section in the corresponding json file. It is inherently not intuitive to use ";" as the default of the csv decoder.

Before merging, the documentation should be checked for any issues with examples or data ingestion in general.