### PR TITLE
Implement plotly

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -9,6 +9,7 @@ sphinx-autoapi
 IPython
 m2r2
 sphinx-gallery
+plotly
 matplotlib >= 3.4.0
 sphinx-rtd-theme
 sphinx_autopackagesummary

--- a/examples/03_data_features/001_receptor_densities.py
+++ b/examples/03_data_features/001_receptor_densities.py
@@ -44,8 +44,7 @@ v1_fingerprints = siibra.features.get(
     siibra.get_region('julich 2.9', 'v1'),
     siibra.features.molecular.ReceptorDensityFingerprint
 )
-for fp in v1_fingerprints:
-    fig = fp.plot()
+v1_fingerprints[0].plot()
 
 # %%
 # Each feature includes a data structure for the fingerprint, with mean and
@@ -68,7 +67,5 @@ for p in v1_profiles:
     if "GABAA" in p.receptor:
         print(p.receptor)
         break
+print(p.data)
 p.plot()
-p.data
-
-# %%

--- a/examples/03_data_features/007_comparative_assessment.py
+++ b/examples/03_data_features/007_comparative_assessment.py
@@ -57,7 +57,7 @@ for i, region in enumerate(regions):
         print(region, modality, len(features))
         if len(features) > 0:
             fp = features[-1]
-            fp.plot(ax=axs[j, i], backend='matplotlib')
+            fp.plot(ax=axs[j, i])
             axs[j, i].set_ylim(0, ymax[j])
 f.tight_layout()
 
@@ -83,6 +83,6 @@ for i, region in enumerate(regions):
         )
         # fetch a random sample from the available ones
         p = features[int(np.random.rand() * (len(features)))]
-        p.plot(ax=axs[j, i], layercolor="darkblue", backend='matplotlib')
+        p.plot(ax=axs[j, i], layercolor="darkblue")
         axs[j, i].set_ylim(0, ymax[j])
 f.tight_layout()

--- a/examples/03_data_features/007_comparative_assessment.py
+++ b/examples/03_data_features/007_comparative_assessment.py
@@ -57,7 +57,7 @@ for i, region in enumerate(regions):
         print(region, modality, len(features))
         if len(features) > 0:
             fp = features[-1]
-            fp.plot(ax=axs[j, i])
+            fp.plot(ax=axs[j, i], backend='matplotlib')
             axs[j, i].set_ylim(0, ymax[j])
 f.tight_layout()
 
@@ -75,6 +75,7 @@ f, axs = plt.subplots(len(modalities), len(regions))
 f.set(figheight=15, figwidth=10)
 ymax = [3500, 150, 30000]
 
+np.random.seed(1)  # for reproducibility
 for i, region in enumerate(regions):
     for j, (modality, filterfunc) in enumerate(modalities):
         features = list(
@@ -82,6 +83,6 @@ for i, region in enumerate(regions):
         )
         # fetch a random sample from the available ones
         p = features[int(np.random.rand() * (len(features)))]
-        p.plot(ax=axs[j, i], layercolor="darkblue")
+        p.plot(ax=axs[j, i], layercolor="darkblue", backend='matplotlib')
         axs[j, i].set_ylim(0, ymax[j])
 f.tight_layout()

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -24,6 +24,7 @@ import pandas as pd
 from typing import Generic, Iterable, Iterator, List, TypeVar, Union, Dict
 from skimage.filters import gaussian
 from dataclasses import dataclass
+from importlib.util import find_spec
 
 logger = logging.getLogger(__name__.split(os.path.extsep)[0])
 ch = logging.StreamHandler()
@@ -44,6 +45,9 @@ SIIBRA_USE_LOCAL_SNAPSPOT = os.getenv("SIIBRA_USE_LOCAL_SNAPSPOT")
 
 with open(os.path.join(ROOT_DIR, "VERSION"), "r") as fp:
     __version__ = fp.read().strip()
+
+if find_spec("plotly") is not None:
+    pd.options.plotting.backend = "plotly"
 
 @dataclass
 class CompareMapsResult:

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -24,7 +24,6 @@ import pandas as pd
 from typing import Generic, Iterable, Iterator, List, TypeVar, Union, Dict
 from skimage.filters import gaussian
 from dataclasses import dataclass
-from importlib.util import find_spec
 
 logger = logging.getLogger(__name__.split(os.path.extsep)[0])
 ch = logging.StreamHandler()
@@ -46,8 +45,6 @@ SIIBRA_USE_LOCAL_SNAPSPOT = os.getenv("SIIBRA_USE_LOCAL_SNAPSPOT")
 with open(os.path.join(ROOT_DIR, "VERSION"), "r") as fp:
     __version__ = fp.read().strip()
 
-if find_spec("plotly") is not None:
-    pd.options.plotting.backend = "plotly"
 
 @dataclass
 class CompareMapsResult:

--- a/siibra/features/connectivity/regional_connectivity.py
+++ b/siibra/features/connectivity/regional_connectivity.py
@@ -170,14 +170,18 @@ class RegionalConnectivity(Feature):
             "title",
             f"{subject_title} - {self.modality} in {', '.join({_.name for _ in self.anchor.regions})}"
         )
-        kwargs["figure"] = kwargs.get("figure", (15, 15))
 
-        from nilearn import plotting
-        plotting.plot_matrix(
-            matrix,
-            labels=regions,
-            **kwargs
-        )
+        if not kwargs.get("reorder") and pd.options.plotting.backend == "plotly":
+            from plotly.express import imshow
+            return imshow(matrix, x=regions, y=regions, **kwargs)
+        else:
+            kwargs["figure"] = kwargs.get("figure", (15, 15))
+            from nilearn import plotting
+            plotting.plot_matrix(
+                matrix,
+                labels=regions,
+                **kwargs
+            )
 
     def __iter__(self):
         return ((sid, self.get_matrix(sid)) for sid in self._files)

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -155,6 +155,10 @@ class Feature:
         )
         return cls._preconfigured_instances
 
+    def plot(self, *args, **kwargs):
+        """Feature subclasses override this with their customized plot methods."""
+        raise NotImplementedError("Generic feature class does not have a standardized plot.")
+
     @classmethod
     def clean_instances(cls):
         """ Removes all instantiated object instances"""

--- a/siibra/features/tabular/cortical_profile.py
+++ b/siibra/features/tabular/cortical_profile.py
@@ -169,7 +169,7 @@ class CorticalProfile(tabular.Tabular):
         wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
 
         kwargs["title"] = kwargs.get("title", "\n".join(wrap(self.name, wrapwidth)))
-        if pd.options.plotting.backend == "plotly":
+        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
             return self.data.plot(**kwargs)
         else:
             kwargs["xlabel"] = kwargs.get("xlabel", "Cortical depth")

--- a/siibra/features/tabular/cortical_profile.py
+++ b/siibra/features/tabular/cortical_profile.py
@@ -159,25 +159,30 @@ class CorticalProfile(tabular.Tabular):
             self._values, index=self._depths, columns=[f"{self.modality} ({self.unit})"]
         )
 
-    def plot(self, **kwargs):
+    def plot(self, *args, backend="matplotlib", **kwargs):
         """
         Plot the profile.
 
-        Keyword arguments are passed on to the plot command.
-        'layercolor' can be used to specify a color for cortical layer shading.
+        Parameters
+        ----------
+        backend: str
+            "matplotlib", "plotly", or others supported by pandas DataFrame
+            plotting backend.
+        **kwargs
+            Keyword arguments are passed on to the plot command.
+            'layercolor' can be used to specify a color for cortical layer shading.
         """
         wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
 
         kwargs["title"] = kwargs.get("title", "\n".join(wrap(self.name, wrapwidth)))
-        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
-            return self.data.plot(**kwargs)
-        else:
+
+        if backend == "matplotlib":
             kwargs["xlabel"] = kwargs.get("xlabel", "Cortical depth")
             kwargs["ylabel"] = kwargs.get("ylabel", self.unit)
             kwargs["grid"] = kwargs.get("grid", True)
             kwargs["ylim"] = kwargs.get("ylim", (0, max(self._values)))
             layercolor = kwargs.pop("layercolor") if "layercolor" in kwargs else "black"
-            axs = self.data.plot(**kwargs)
+            axs = self.data.plot(*args, **kwargs, backend=backend)
 
             if self.boundaries_mapped:
                 bvals = list(self.boundary_positions.values())
@@ -194,6 +199,8 @@ class CorticalProfile(tabular.Tabular):
 
             axs.set_title(axs.get_title(), fontsize="medium")
             return axs
+        else:
+            return self.data.plot(*args, **kwargs, backend=backend)
 
     @property
     def _depths(self):

--- a/siibra/features/tabular/cortical_profile.py
+++ b/siibra/features/tabular/cortical_profile.py
@@ -169,29 +169,31 @@ class CorticalProfile(tabular.Tabular):
         wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
 
         kwargs["title"] = kwargs.get("title", "\n".join(wrap(self.name, wrapwidth)))
-        kwargs["xlabel"] = kwargs.get("xlabel", "Cortical depth")
-        kwargs["ylabel"] = kwargs.get("ylabel", self.unit)
-        kwargs["grid"] = kwargs.get("grid", True)
-        kwargs["ylim"] = kwargs.get("ylim", (0, max(self._values)))
-        layercolor = kwargs.pop("layercolor") if "layercolor" in kwargs else "black"
-        axs = self.data.plot(**kwargs)
+        if pd.options.plotting.backend == "plotly":
+            return self.data.plot(**kwargs)
+        else:
+            kwargs["xlabel"] = kwargs.get("xlabel", "Cortical depth")
+            kwargs["ylabel"] = kwargs.get("ylabel", self.unit)
+            kwargs["grid"] = kwargs.get("grid", True)
+            kwargs["ylim"] = kwargs.get("ylim", (0, max(self._values)))
+            layercolor = kwargs.pop("layercolor") if "layercolor" in kwargs else "black"
+            axs = self.data.plot(**kwargs)
 
-        if self.boundaries_mapped:
-            bvals = list(self.boundary_positions.values())
-            for i, (d1, d2) in enumerate(list(zip(bvals[:-1], bvals[1:]))):
-                axs.text(
-                    d1 + (d2 - d1) / 2.0,
-                    10,
-                    self.LAYERS[i + 1],
-                    weight="normal",
-                    ha="center",
-                )
-                if i % 2 == 0:
-                    axs.axvspan(d1, d2, color=layercolor, alpha=0.1)
+            if self.boundaries_mapped:
+                bvals = list(self.boundary_positions.values())
+                for i, (d1, d2) in enumerate(list(zip(bvals[:-1], bvals[1:]))):
+                    axs.text(
+                        d1 + (d2 - d1) / 2.0,
+                        10,
+                        self.LAYERS[i + 1],
+                        weight="normal",
+                        ha="center",
+                    )
+                    if i % 2 == 0:
+                        axs.axvspan(d1, d2, color=layercolor, alpha=0.1)
 
-        axs.set_title(axs.get_title(), fontsize="medium")
-
-        return axs
+            axs.set_title(axs.get_title(), fontsize="medium")
+            return axs
 
     @property
     def _depths(self):

--- a/siibra/features/tabular/gene_expression.py
+++ b/siibra/features/tabular/gene_expression.py
@@ -16,7 +16,7 @@
 from .. import anchor as _anchor
 from . import tabular
 
-from ... import commons
+from ... import logger
 
 import pandas as pd
 from textwrap import wrap
@@ -118,28 +118,38 @@ class GeneExpressions(
         )
         self.unit = "expression level"
 
-    def plot(self, **kwargs):
-        """ Create a bar plot of the average per gene."""
+    def plot(self, *args, backend="matplotlib", **kwargs):
+        """
+        Create a bar plot of the average per gene.
+        Parameters
+        ----------
+        backend: str
+            "matplotlib", "plotly", or others supported by pandas DataFrame
+            plotting backend.
+        **kwargs
+            Keyword arguments are passed on to the plot command.
+        """
         wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
         title = kwargs.pop("title", None) \
-                or "\n".join(wrap(f"{self.modality} measured in {self.anchor._regionspec}", wrapwidth))
-        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
-            return self.data.plot(kind='box', y='level', x='gene', **kwargs)
-        else:
+            or "\n".join(wrap(f"{self.modality} measured in {self.anchor._regionspec}", wrapwidth))
+        if backend == "matplotlib":
             try:
                 import matplotlib.pyplot as plt
             except ImportError:
-                commons.logger.error("matplotlib not available. Plotting of fingerprints disabled.")
-                return None
+                logger.error("matplotlib not available. Plotting of fingerprints disabled.")
+                raise
 
             for arg in ['yerr', 'y', 'ylabel', 'xlabel', 'width']:
                 assert arg not in kwargs
+            passed_kwarg = {
+                "kind": 'box', "grid": True, "legend": False, 'by': "gene",
+                'column': ['level'], 'showfliers': False, 'ax': None,
+                **kwargs
+            }
+            ax = self.data.plot(
+                *args, **passed_kwarg, backend=backend
+            )
 
-            kwargs["grid"] = kwargs.get("grid", True)
-            kwargs["legend"] = kwargs.get("legend", False)
-
-            # ax = plot_data.plot(kind="bar", **kwargs)
-            ax = self.data.boxplot(column=['level'], by='gene', ax=kwargs.get('ax', None), showfliers=False)
             plt.title('')
             plt.suptitle('')
             ax.set_title(title, fontsize="medium")
@@ -147,3 +157,6 @@ class GeneExpressions(
             ax.set_xlabel("")
 
             plt.tight_layout()
+            return ax
+        else:
+            return self.data.plot(kind='box', y='level', x='gene', **kwargs)

--- a/siibra/features/tabular/gene_expression.py
+++ b/siibra/features/tabular/gene_expression.py
@@ -120,8 +120,11 @@ class GeneExpressions(
 
     def plot(self, **kwargs):
         """ Create a bar plot of the average per gene."""
-        if pd.options.plotting.backend == "plotly":
-            return self.data.plot(kind='box', **kwargs)
+        wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
+        title = kwargs.pop("title", None) \
+                or "\n".join(wrap(f"{self.modality} measured in {self.anchor._regionspec}", wrapwidth))
+        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
+            return self.data.plot(kind='box', y='level', x='gene', **kwargs)
         else:
             try:
                 import matplotlib.pyplot as plt
@@ -129,13 +132,9 @@ class GeneExpressions(
                 commons.logger.error("matplotlib not available. Plotting of fingerprints disabled.")
                 return None
 
-            wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
-
             for arg in ['yerr', 'y', 'ylabel', 'xlabel', 'width']:
                 assert arg not in kwargs
 
-            title = kwargs.pop("title", None) \
-                or "\n".join(wrap(f"{self.modality} measured in {self.anchor._regionspec}", wrapwidth))
             kwargs["grid"] = kwargs.get("grid", True)
             kwargs["legend"] = kwargs.get("legend", False)
 

--- a/siibra/features/tabular/layerwise_cell_density.py
+++ b/siibra/features/tabular/layerwise_cell_density.py
@@ -109,6 +109,6 @@ class LayerwiseCellDensity(
             self.regionspec
         ))
 
-    def plot(self, **kwargs):
+    def plot(self, *args, **kwargs):
         kwargs['ylabel'] = self.unit
-        super().plot(**kwargs)
+        super().plot(*args, **kwargs)

--- a/siibra/features/tabular/receptor_density_fingerprint.py
+++ b/siibra/features/tabular/receptor_density_fingerprint.py
@@ -91,7 +91,7 @@ class ReceptorDensityFingerprint(
                 columns=['mean', 'std']
             )
             self._data_cached.index.name = 'receptor'
-        return self._data_cached
+        return self._data_cached.copy()
 
     @classmethod
     def parse_tsv_data(cls, data: dict):
@@ -113,47 +113,67 @@ class ReceptorDensityFingerprint(
 
     def polar_plot(self, **kwargs):
         """ Create a polar plot of the fingerprint. """
-        try:
-            import matplotlib.pyplot as plt
-        except ImportError:
-            commons.logger.error("matplotlib not available. Plotting of fingerprints disabled.")
-            return None
-        from collections import deque
+        if pd.options.plotting.backend == "plotly":
+            from plotly.express import line_polar
+            df = pd.DataFrame(
+                {
+                    "values": pd.concat(
+                        [
+                            self.data["mean"],
+                            self.data["mean"] - self.data["std"],
+                            self.data["mean"] + self.data["std"]
+                        ]
+                    ),
+                    "cat":
+                        len(self.data) * ["mean"] +\
+                        len(self.data) * ["mean - std"] +\
+                        len(self.data) * ["mean + std"]
+                }
+            )
+            return line_polar(df, r="values", theta=df.index, color="cat",
+                line_close=True, **kwargs)
+        else:
+            try:
+                import matplotlib.pyplot as plt
+            except ImportError:
+                commons.logger.error("matplotlib not available. Plotting of fingerprints disabled.")
+                return None
+            from collections import deque
 
-        # default args
-        wrapwidth = 40
-        y = kwargs.pop("y") if "y" in kwargs else self.data.columns[0]
-        yerr = kwargs.pop("yerr") if "yerr" in kwargs else None
-        if yerr is None:
-            yerr = 'std' if 'std' in self.data.columns else None
-        ax = kwargs.pop("ax") if "ax" in kwargs else plt.subplot(111, projection="polar")
+            # default args
+            wrapwidth = 40
+            y = kwargs.pop("y") if "y" in kwargs else self.data.columns[0]
+            yerr = kwargs.pop("yerr") if "yerr" in kwargs else None
+            if yerr is None:
+                yerr = 'std' if 'std' in self.data.columns else None
+            ax = kwargs.pop("ax") if "ax" in kwargs else plt.subplot(111, projection="polar")
 
-        datafield = y or self.data.columns[0]
-        if yerr is None and 'std' in self.data.columns:
-            yerr = 'std'
-        # values = list(self.data[datafield])
-        angles = deque(np.linspace(0, 2 * np.pi, self.data.shape[0] + 1)[:-1][::-1])
-        angles.rotate(5)
-        angles = list(angles)
-        # for the values, repeat the first element to have a closed plot
-        indices = list(range(self.data.shape[0])) + [0]
-        y = list(self.data[datafield].iloc[indices])
-        plt.plot(angles + [angles[0]], y, "k-", lw=3, **kwargs)
-        if yerr:
-            bounds0 = y - self.data[yerr].iloc[indices]
-            plt.plot(angles + [angles[0]], bounds0, "k", lw=0.5, **kwargs)
-            bounds1 = y + self.data[yerr].iloc[indices]
-            plt.plot(angles + [angles[0]], bounds1, "k", lw=0.5, **kwargs)
-        ax.set_xticks(angles)
-        ax.set_xticklabels([_ for _ in self.data.index])
-        ax.set_ylabel(self.unit)
-        ax.set_title(
-            "\n".join(wrap(f"{self.modality} anchored at {self.anchor._regionspec}", wrapwidth))
-        )
-        ax.tick_params(pad=9, labelsize=10)
-        ax.tick_params(axis="y", labelsize=8)
-        plt.tight_layout()
-        return ax
+            datafield = y or self.data.columns[0]
+            if yerr is None and 'std' in self.data.columns:
+                yerr = 'std'
+            # values = list(self.data[datafield])
+            angles = deque(np.linspace(0, 2 * np.pi, self.data.shape[0] + 1)[:-1][::-1])
+            angles.rotate(5)
+            angles = list(angles)
+            # for the values, repeat the first element to have a closed plot
+            indices = list(range(self.data.shape[0])) + [0]
+            y = list(self.data[datafield].iloc[indices])
+            plt.plot(angles + [angles[0]], y, "k-", lw=3, **kwargs)
+            if yerr:
+                bounds0 = y - self.data[yerr].iloc[indices]
+                plt.plot(angles + [angles[0]], bounds0, "k", lw=0.5, **kwargs)
+                bounds1 = y + self.data[yerr].iloc[indices]
+                plt.plot(angles + [angles[0]], bounds1, "k", lw=0.5, **kwargs)
+            ax.set_xticks(angles)
+            ax.set_xticklabels([_ for _ in self.data.index])
+            ax.set_ylabel(self.unit)
+            ax.set_title(
+                "\n".join(wrap(f"{self.modality} anchored at {self.anchor._regionspec}", wrapwidth))
+            )
+            ax.tick_params(pad=9, labelsize=10)
+            ax.tick_params(axis="y", labelsize=8)
+            plt.tight_layout()
+            return ax
 
     def plot(self, **kwargs):
         kwargs['xlabel'] = ""

--- a/siibra/features/tabular/receptor_density_fingerprint.py
+++ b/siibra/features/tabular/receptor_density_fingerprint.py
@@ -113,7 +113,7 @@ class ReceptorDensityFingerprint(
 
     def polar_plot(self, **kwargs):
         """ Create a polar plot of the fingerprint. """
-        if pd.options.plotting.backend == "plotly":
+        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
             from plotly.express import line_polar
             df = pd.DataFrame(
                 {

--- a/siibra/features/tabular/receptor_density_fingerprint.py
+++ b/siibra/features/tabular/receptor_density_fingerprint.py
@@ -111,28 +111,13 @@ class ReceptorDensityFingerprint(
             'stds': [float(s) if s.isnumeric() else 0 for s in std],
         }
 
-    def polar_plot(self, **kwargs):
-        """ Create a polar plot of the fingerprint. """
-        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
-            from plotly.express import line_polar
-            df = pd.DataFrame(
-                {
-                    "values": pd.concat(
-                        [
-                            self.data["mean"],
-                            self.data["mean"] - self.data["std"],
-                            self.data["mean"] + self.data["std"]
-                        ]
-                    ),
-                    "cat":
-                        len(self.data) * ["mean"] +\
-                        len(self.data) * ["mean - std"] +\
-                        len(self.data) * ["mean + std"]
-                }
-            )
-            return line_polar(df, r="values", theta=df.index, color="cat",
-                line_close=True, **kwargs)
-        else:
+    def polar_plot(self, *args, backend='matplotlib', **kwargs):
+        """
+        Create a polar plot of the fingerprint.
+        backend: str
+            "matplotlib" or "plotly"
+        """
+        if backend == "matplotlib":
             try:
                 import matplotlib.pyplot as plt
             except ImportError:
@@ -174,7 +159,29 @@ class ReceptorDensityFingerprint(
             ax.tick_params(axis="y", labelsize=8)
             plt.tight_layout()
             return ax
+        elif backend == "plotly":
+            from plotly.express import line_polar
+            df = pd.DataFrame(
+                {
+                    "values": pd.concat(
+                        [
+                            self.data["mean"],
+                            self.data["mean"] - self.data["std"],
+                            self.data["mean"] + self.data["std"]
+                        ]
+                    ),
+                    "cat":
+                        len(self.data) * ["mean"] +\
+                        len(self.data) * ["mean - std"] +\
+                        len(self.data) * ["mean + std"]
+                }
+            )
+            return line_polar(
+                df, r="values", theta=df.index, color="cat", line_close=True, **kwargs
+            )
+        else:
+            raise NotImplementedError
 
-    def plot(self, **kwargs):
+    def plot(self, *args, **kwargs):
         kwargs['xlabel'] = ""
-        return super().plot(**kwargs)
+        return super().plot(*args, **kwargs)

--- a/siibra/features/tabular/regional_timeseries_activity.py
+++ b/siibra/features/tabular/regional_timeseries_activity.py
@@ -196,10 +196,10 @@ class RegionalTimeseriesActivity(tabular.Tabular):
             df = df.rename(columns=remapper)
         return df
 
-    def plot(self, subject: str = None, **kwargs):
+    def plot(self, subject: str = None, *args, backend="matplotlib", **kwargs):
         table = self.get_table(subject)
         table.columns = [str(r) for r in table.columns]
-        return table.mean().plot(kind="bar", **kwargs)
+        return table.mean().plot(kind="bar", *args, backend=backend, **kwargs)
 
 
 class RegionalBOLD(

--- a/siibra/features/tabular/tabular.py
+++ b/siibra/features/tabular/tabular.py
@@ -65,8 +65,12 @@ class Tabular(feature.Feature):
         **kwargs
             takes Matplotlib.pyplot keyword arguments
         """
-        if pd.options.plotting.backend == "plotly":
-            _ = kwargs.pop("xlabel")
+        kwargs["y"] = kwargs.get("y", self.data.columns[0])
+        if pd.options.plotting.backend == "plotly" and kwargs.get("backend") != "matplotlib":
+            kwargs["labels"] = {
+                "index": kwargs.pop("xlabel", ""),
+                "value": kwargs.pop("ylabel", f"{kwargs.get('y')} {self.unit if hasattr(self, 'unit') else ''}")
+            }
             kwargs["error_y"] = kwargs.get("yerr", 'std' if 'std' in self.data.columns else None)
             return self.data.plot(kind="bar", **kwargs)
         else:
@@ -78,7 +82,6 @@ class Tabular(feature.Feature):
 
             wrapwidth = kwargs.pop("textwrap") if "textwrap" in kwargs else 40
             # default kwargs
-            kwargs["y"] = kwargs.get("y", self.data.columns[0])
             if kwargs.get("error_y") is None:
                 kwargs["yerr"] = kwargs.get("yerr", 'std' if 'std' in self.data.columns else None)
             kwargs["width"] = kwargs.get("width", 0.95)


### PR DESCRIPTION
Note that pandas can use plotly as the backend visualization grammar by pd.options.plotting.backend = "plotly". For simplicity and keeping requirements of siibra-python low, [a prototype implementation](https://github.com/FZJ-INM1-BDA/siibra-python/tree/implementPlotly) has been written.
If plotly is installed in the environment, the plot functions use plotly and return as a plotly.graph_objects.Figure. This object has to_json() method which can be used for siibra-api.

Example: https://siibra-python.readthedocs.io/en/implementplotly/examples/03_data_features/001_receptor_densities.html