### PR TITLE
If no format is given, only try to fetch single format else fail

### DIFF
--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -52,6 +52,22 @@ class Volume:
 
     SUPPORTED_FORMATS = IMAGE_FORMATS + MESH_FORMATS
 
+    _FORMAT_LOOKUP = {
+        "image": IMAGE_FORMATS,
+        "mesh": MESH_FORMATS,
+        "surface": MESH_FORMATS,
+        "nifti": ["nii", "zip/nii"],
+        "nii": ["nii", "zip/nii"],
+        "neuroglancer": [
+            "neuroglancer/precomputed",
+            "neuroglancer/precompmesh",
+            "neuroglancer/precompmesh/surface"],
+        "neuroglancer mesh": [
+            "neuroglancer/precompmesh",
+            "neuroglancer/precompmesh/surface"
+        ]
+    }
+
     def __init__(
         self,
         space_spec: dict,
@@ -159,9 +175,10 @@ class Volume:
 
         Parameters
         ----------
-        format: str
-            Requested format. Per default, several formats are tried,
-            starting with volumetric formats. It can be explicitly specified as:
+        format: str, default=None
+            Requested format. If `None`, the first supported format matching in
+            `self.formats` is tried, starting with volumetric formats.
+            It can be explicitly specified as:
                 - 'surface' or 'mesh' to fetch a surface format
                 - 'volumetric' or 'voxel' to fetch a volumetric format
                 - supported format types, see SUPPORTED_FORMATS. This includes
@@ -175,29 +192,38 @@ class Volume:
 
         if format is None:
             requested_formats = self.SUPPORTED_FORMATS
-        elif format == 'mesh':
-            requested_formats = self.MESH_FORMATS
-        elif format == 'image':
-            requested_formats = self.IMAGE_FORMATS
+        elif format in self._FORMAT_LOOKUP.keys():  # allow use of aliases
+            requested_formats = self._FORMAT_LOOKUP[format]
         elif format in self.SUPPORTED_FORMATS:
             requested_formats = [format]
         else:
             raise ValueError(f"Invalid format requested: {format}")
 
+        # select the first source unless the user specifically requests a format
         for fmt in requested_formats:
             if fmt in self.formats:
-                try:
-                    if fmt == "gii-label":
-                        tpl = self.space.get_template(variant=kwargs.get('variant'))
-                        mesh = tpl.fetch(**kwargs)
-                        labels = self._providers[fmt].fetch(**kwargs)
-                        return dict(**mesh, **labels)
-                    else:
-                        return self._providers[fmt].fetch(**kwargs)
-                except requests.SiibraHttpRequestError as e:
-                    logger.error(f"Cannot access {self._providers[fmt]}")
-                    print(str(e))
-                    continue
+                selected_format = fmt
+                break
+        else:
+            raise ValueError(f"Invalid format requested: {format}")
+        
+        # try the selected format only
+        for try_count in range(6):
+            try:
+                if selected_format == "gii-label":
+                    tpl = self.space.get_template(variant=kwargs.get('variant'))
+                    mesh = tpl.fetch(**kwargs)
+                    labels = self._providers[selected_format].fetch(**kwargs)
+                    return dict(**mesh, **labels)
+                else:
+                    return self._providers[selected_format].fetch(**kwargs)
+            except requests.SiibraHttpRequestError:
+                logger.error(f"Cannot access {self._providers[selected_format]}", exc_info=(try_count == 5))
+        if format is None and len(self.formats) > 1:
+            logger.info(
+                f"No format was specified and auto-selected {selected_format} "
+                f"was unsuccesful. You can specify another format from "
+                f" {set(self.formats) - set(selected_format)} to try.")
         return None
 
 


### PR DESCRIPTION
Provides a solution to #318 (and closes #368):
- Fetch the first supported format matching the volume's providers unless the user specifies the volume `format`.
- Try the selected format 6 times and fail.
- On fail, inform the user of the exception, the autoselected format, and other available formats.

Also, adds a lookup dictionary for format shorthand (solves #386)
