### PR TITLE
Add homologies for rat and monkey brains

### DIFF
--- a/siibra/vocabularies/region_aliases.json
+++ b/siibra/vocabularies/region_aliases.json
@@ -456,34 +456,34 @@
 				"globus pallidus": "exact"
 			}
 		},
-		"Area hOc1 (V1, 17, CalcS)": {
-			"Macaca fascicularis": {
-				"V1": "exact"
+		"V1": {
+			"Homo sapiens": {
+				"Area hOc1 (V1, 17, CalcS)": "exact"
 			}
 		},
-		"Area hOc2 (V2, 18)": {
-			"Macaca fascicularis": {
-				"V2": "exact"
+		"V2": {
+			"Homo sapiens": {
+				"Area hOc2 (V2, 18)": "exact"
 			}
 		},
-		"Area 4a (PreCG)": {
-			"Macaca fascicularis": {
-				"4a": "exact"
+		"4a": {
+			"Homo sapiens": {
+				"Area 4a (PreCG)": "exact"
 			}
 		},
-		"Area 4p (PreCG)": {
-			"Macaca fascicularis": {
-				"4p": "exact"
+		"4p": {
+			"Homo sapiens": {
+				"Area 4p (PreCG)": "exact"
 			}
 		},
-		"Area PGp (IPL)": {
-			"Macaca fascicularis": {
-				"Opt": "exact"
+		"Opt": {
+			"Homo sapiens": {
+				"Area PGp (IPL)": "exact"
 			}
 		},
-		"Area PGa (IPL)": {
-			"Macaca fascicularis": {
-				"PG": "exact"
+		"PG": {
+			"Homo sapiens": {
+				"Area PGa (IPL)": "exact"
 			}
 		}
 	},

--- a/siibra/vocabularies/region_aliases.json
+++ b/siibra/vocabularies/region_aliases.json
@@ -455,6 +455,36 @@
 			"Macaca fascicularis": {
 				"globus pallidus": "exact"
 			}
+		},
+		"Area hOc1 (V1, 17, CalcS)": {
+			"Macaca fascicularis": {
+				"V1": "exact"
+			}
+		},
+		"Area hOc2 (V2, 18)": {
+			"Macaca fascicularis": {
+				"V2": "exact"
+			}
+		},
+		"Area 4a (PreCG)": {
+			"Macaca fascicularis": {
+				"4a": "exact"
+			}
+		},
+		"Area 4p (PreCG)": {
+			"Macaca fascicularis": {
+				"4p": "exact"
+			}
+		},
+		"Area PGp (IPL)": {
+			"Macaca fascicularis": {
+				"Opt": "exact"
+			}
+		},
+		"Area PGa (IPL)": {
+			"Macaca fascicularis": {
+				"PG": "exact"
+			}
 		}
 	}
 }

--- a/siibra/vocabularies/region_aliases.json
+++ b/siibra/vocabularies/region_aliases.json
@@ -486,5 +486,28 @@
 				"PG": "exact"
 			}
 		}
+	},
+	"Rattus norvegicus": {
+		"Primary visual area": {
+			"Rattus norvegicus": {
+				"Oc1M": "contains",
+				"Oc1B": "contains"
+			}
+		},
+		"Oc2L ": {
+			"Rattus norvegicus": {
+				"Secondary visual area, lateral part": "exact"
+			}
+		},
+		"Oc2M": {
+			"Rattus norvegicus": {
+				"Secondary visual area, medial part": "exact"
+			}
+		},
+		"DG": {
+			"Rattus norvegicus": {
+				"Dentate gyrus": "exact"
+			}
+		}
 	}
 }


### PR DESCRIPTION
Here is information provided by Prof. Dr. Nicola Palomero-Gallagher:

> CA1, CA2 and CA3 correspond to the Cornu ammonis 1, Cornu ammonis 2 and Cornu ammonis 3 regions in the Waxholm rat atlas, respectively. The receptor data already seems to be linked to these areas.
> DG is also easy enough. That is the dentate gyrus. And the receptor data has already been linked to this
> CA-cellulare and CA-moleculare are more difficult to link. Sometimes the CA1-CA3 regions are merged to a single region called CA.  So CA = CA1 + CA2 + CA3 (see attached powerpoint). And that is, to a certain degree, what has been done here. However, within each of the CA regions, we can distinguish a layer with the cell bodies (cellulare layer) and a layer with the dendrites (moleculare layer). So CA-cellulare = CA1-cellulare + CA2-cellulare + CA3-cellulare.
> The problem is, that the molecular and cellular layers of the CA1-CA3 regions have not been defined in the Waxholm space.  The easiest thing to say is that CA-cellulare = part of CA1 + part of CA2 + part of CA3
> 
> Oc1B and Oc1M are parts of “Primary visual area” in the Waxholm atlas. So that Oc1M and Oc1B together are equal to the Primary visual area.
> Oc2L is “Secondary visual area, lateral part” in the Waxholm atlas
> Oc2M is “Secondary visual area, medial part” in the Waxholm atlas

TODO:
- [ ] Double-check wording ("contains", "contained" etc)
- [ ] In light of this information, the rat receptor datasets concerning cornu ammonis included in version 04a51 (see https://search.kg.ebrains.eu/instances/77aeb65e-9ff1-46b2-9f58-e11b2a0687d2) could be updated.
```python
# for easy access
import siibra
fts = [f for f in siibra.features.molecular.ReceptorDensityFingerprint.get_instances() if siibra.commons.Species.RATTUS_NORVEGICUS in f.anchor.species]
```