### PR TITLE
Allow using local configs with feature folder hierarchy on Windows

### DIFF
--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -371,6 +371,11 @@ def snake2camel(s: str):
     return "".join([w[0].upper() + w[1:].lower() for w in s.split("_")])
 
 
+def normalize_path(s: str):
+    """Path normalization wrapper."""
+    return os.path.normpath(s)
+
+
 # getting nonzero pixels of pmaps is one of the most time consuming tasks when computing metrics,
 # so we cache the nonzero coordinates of array objects at runtime.
 NZCACHE = {}

--- a/siibra/configuration/configuration.py
+++ b/siibra/configuration/configuration.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..commons import logger, __version__, SIIBRA_USE_CONFIGURATION, siibra_tqdm
+from ..commons import logger, __version__, SIIBRA_USE_CONFIGURATION, siibra_tqdm, normalize_path
 from ..retrieval.repositories import GitlabConnector, RepositoryConnector
 from ..retrieval.exceptions import NoSiibraConfigMirrorsAvailableException
 from ..retrieval.requests import SiibraHttpRequestError
@@ -145,8 +145,11 @@ class Configuration:
         result = []
 
         if folder not in self.folders:
-            logger.warning(f"No configuration found for building from configuration folder {folder}.")
-            return result
+            if normalize_path(folder) in self.folders:
+                folder = normalize_path(folder)
+            else:
+                logger.warning(f"No configuration found for building from configuration folder {folder}.")
+                return result
 
         from .factory import Factory
         specloaders = self.spec_loaders.get(folder, [])

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -15,7 +15,7 @@
 
 from . import anchor as _anchor
 
-from ..commons import logger, InstanceTable, siibra_tqdm
+from ..commons import logger, InstanceTable, siibra_tqdm, normalize_path
 from ..core import concept
 from ..core import space, region, parcellation
 
@@ -144,7 +144,11 @@ class Feature:
         from ..configuration.configuration import Configuration
         conf = Configuration()
         Configuration.register_cleanup(cls.clean_instances)
-        assert cls._configuration_folder in conf.folders
+        try:
+            assert cls._configuration_folder in conf.folders
+        except Exception:
+            logger.debug("Configuration folder assertion has failed:", exc_info=1)
+            assert normalize_path(cls._configuration_folder) in conf.folders, "Configuration folder assertion has failed"
         cls._preconfigured_instances = [
             o for o in conf.build_objects(cls._configuration_folder)
             if isinstance(o, cls)


### PR DESCRIPTION
Currently, when local configuration is used on Windows machines, the feature folder system cannot be used. This PR addresses this issue.
Related to #292. (we can use the same solution for ebrains snapshot)