### PR TITLE
Digest unparcellated_regions from map specs

### DIFF
--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -281,6 +281,7 @@ class Factory:
             space_spec=spec.get("space", {}),
             parcellation_spec=spec.get("parcellation", {}),
             indices=spec.get("indices", {}),
+            unparcellated_regions=spec.get("unparcellated regions", []),
             volumes=volumes,
             shortname=spec.get("shortName", ""),
             description=spec.get("description"),

--- a/siibra/volumes/sparsemap.py
+++ b/siibra/volumes/sparsemap.py
@@ -220,6 +220,7 @@ class SparseMap(parcellationmap.Map):
         space_spec: dict,
         parcellation_spec: dict,
         indices: Dict[str, MapIndex],
+        unparcellated_regions: List[str] = [],
         volumes: list = [],
         shortname: str = "",
         description: str = "",


### PR DESCRIPTION
Although some regions are defined in a map configuration with indices (for accuracy), they do not correspond to any regions in the corresponding region. (see https://github.com/FZJ-INM1-BDA/siibra-python/actions/runs/5740796548/job/15559446484?pr=373)
For example, on fsaverage space Julich brain 3 have indices for the following regions but they are not part of the Julich brain 3 region tree.
```json
"unparcellated regions": [
	"BrainStemMask - right hemisphere",
	"BrainStemMask - left hemisphere",
	"CorpusCallosumMask - right hemisphere",
	"CorpusCallosumMask - left hemisphere"
]
```

This PR allows digesting fields such as one above from map configurations and when a use ones to get the region object for their corresponding index, it informs the users and returns None (the same action for when there are not matches).
Also, it allows the `parcellationmap.Map.get_colormap` method to skip such regions. (While they might have a color value, the colors are currently defined in parcellation configurations.)