### PR TITLE
Add custom parcellation maps, compute relations to preconfigured maps, find features based on relations

### DIFF
--- a/examples/05_anatomical_assignment/003_custom_parcellation.py
+++ b/examples/05_anatomical_assignment/003_custom_parcellation.py
@@ -1,0 +1,113 @@
+# Copyright 2018-2023
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Using a custom parcellation map to do approximate feature queries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you might want to use a custom parcellation map to perform feature queries in siibra.
+This brings some challenges as we will see.
+For this example, we retrieve a freely available von Economo map in MNI space from Martijn van den Heuvel's lab.
+"""
+
+
+# %%
+import siibra
+import re  # we need this for text file parsing below
+from nilearn import plotting
+
+# %%
+# Load the custom parcellation map from the online resource. For the retrieval,
+# siibra's zipfile connector is very helpful. We can use the resulting NIfTI
+# to create a custom parcellation map inside siibra.
+
+# connect to the online zip file
+conn = siibra.retrieval.ZipfileConnector(
+    "http://www.dutchconnectomelab.nl/economo/economoMNI152volume.zip"
+)
+
+# the NIfTI file is easily retrieved:
+nifti_map = conn.get("economoMNI152volume/economoMNI152volume.nii.gz")
+
+# The text file with label mappings has a custom format.
+# We provide a simple decoder to extract the list of region/label pairs.
+decoder = lambda b: [
+    re.split(r'\s+', line)[:2]       # fields are separated by one or more whitespaces
+    for line in b.decode().split('\n')
+    if re.match(r'^\d\d\d\d', line)  # only lines starting with 4-digit labels are relevant
+]
+labels = conn.get("economoMNI152volume/economoLUT.txt", decode_func=decoder)
+
+# for efficiency of this example, we create the map from only the first 5 regions
+labels = labels[:6]
+
+# Now we use this to add a custom map to siibra.
+# Note that this assumes our external knowledge that the map is in MNI152 space.
+custom_map = siibra.add_nifti_map(
+    name="Von Economo Atlas",
+    nifti_map=nifti_map,
+    space_spec='mni152',
+    regionnames=[name for label, name in labels],
+    regionlabels=[int(label) for label, name in labels]
+)
+
+# let's plot the final map
+plotting.plot_roi(custom_map.fetch())
+
+
+# %%
+# We can already use this map to find spatial features, such as BigBrain
+# intensity profiles.
+custom_region = custom_map.parcellation.get_region('fcbm')
+profiles = siibra.features.get(
+    custom_region,
+    siibra.features.cellular.BigBrainIntensityProfile
+)
+print(f"{len(profiles)} intensity profiles found.")
+
+# However, we will not find any feature that were linked to brain regions
+# instead of coordinate-based locations. This is beccause siibra does not
+# know about the relationships of the custom parcellation's region and its
+# preconfigured parcellations.
+fingerprints = siibra.features.get(
+    custom_region,
+    siibra.features.molecular.ReceptorDensityFingerprint
+)
+print(f"{len(fingerprints)} receptor fingerprints found.")
+
+# %%
+# To overcome this, we can compute relationships of the custom parcellation
+# to a know parcellation, based on probabilistic assignmet of the different
+# parcels. Let's do that with the Julich-Brain cytoarchitectonic maps.
+custom_map.compute_relations('julich 2.9')
+
+# Now, the system has discovered relationships with known regions
+print(custom_region.related_regions)
+
+# %%
+# After this step, we find receptor fingerprints when executing the same call.
+# The 'last_match' attribute of each feature explains why. We first need to
+# clean the instances as they were collected without the newly calculated
+# relations.
+siibra.features.molecular.ReceptorDensityFingerprint.clean_instances()
+
+# Now let us query again and print the results
+fingerprints = siibra.features.get(
+    custom_region,
+    siibra.features.molecular.ReceptorDensityFingerprint
+)
+print(f"{len(fingerprints)} receptor fingerprints found.")
+fp = fingerprints[0]
+print(f"Found related feature: {fp.name}.\n{fp.last_match_description}\n")

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -50,6 +50,7 @@ set_ebrains_token = _EbrainsRequest.set_token
 fetch_ebrains_token = _EbrainsRequest.fetch_token
 find_regions = _parcellation.Parcellation.find_regions
 from_json = factory.Factory.from_json
+add_nifti_map = _parcellationmap.Map.from_nifti
 
 
 def __getattr__(attr: str):
@@ -141,6 +142,7 @@ def __dir__():
         "get_region",
         "find_regions",
         "get_map",
+        "add_nifti_map",
         "get_template",
         "MapType",
         "Point",

--- a/siibra/core/concept.py
+++ b/siibra/core/concept.py
@@ -180,6 +180,10 @@ class AtlasConcept:
     def key(self):
         return create_key(self.name)
 
+    @property
+    def _spec(self):
+        return {'id': self._id, 'name': self.name}
+
     def __init_subclass__(cls, configuration_folder: str = None):
         """
         This method is called whenever AtlasConcept gets subclassed

--- a/siibra/core/region.py
+++ b/siibra/core/region.py
@@ -33,7 +33,7 @@ from ..commons import (
 import numpy as np
 import re
 import anytree
-from typing import List, Set, Union
+from typing import List, Set, Union, Mapping
 from nibabel import Nifti1Image
 from difflib import SequenceMatcher
 from dataclasses import dataclass, field
@@ -123,6 +123,7 @@ class Region(anytree.NodeMixin, concept.AtlasConcept):
         )
         self._supported_spaces = None  # computed on 1st call of self.supported_spaces
         self._CACHED_REGION_SEARCHES = {}
+        self.related_regions: Mapping['Region', float] = {}
 
     @property
     def id(self):
@@ -694,3 +695,13 @@ class Region(anytree.NodeMixin, concept.AtlasConcept):
         (including this parent region)
         """
         return anytree.PreOrderIter(self)
+
+    def _add_related_region(self, other: 'Region', score: float):
+        """
+        Links a related region object to this region, and assigns it a score
+        between 0.0 and 1.0, where
+        - 0 means dissimilar / disjoint
+        - 1 means identical
+        """
+        assert (0. <= score <= 1.)
+        self.related_regions[other] = score

--- a/siibra/features/dataset/ebrains.py
+++ b/siibra/features/dataset/ebrains.py
@@ -54,7 +54,7 @@ class EbrainsDataFeature(feature.Feature, category="other"):
     @property
     def name(self):
         if self._dataset.name.startswith(" "):
-            f"Ebrains Dataset: {self._dataset.is_version_of[0].name}"
+            return f"Ebrains Dataset: {self._dataset.is_version_of[0].name}"
         else:
             return f"Ebrains Dataset: {self._dataset.name}"
 

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -165,6 +165,20 @@ class Feature:
         cls._preconfigured_instances = None
 
     def matches(self, concept: concept.AtlasConcept) -> bool:
+        """
+        Checks if the concept matches the anchor of a feature instance.
+
+        Parameters
+        ----------
+        concept : concept.AtlasConcept
+            Querried AtlasConcept
+
+        Returns
+        -------
+        bool
+            True if anchor and the concept has a match described by
+            self.last_match_description.
+        """
         if self.anchor and self.anchor.matches(concept):
             self.anchor._last_matched_concept = concept
             return True

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -1273,7 +1273,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
             srclabel = match['input structure']
             srcregion = self.get_region(label=srclabel)
             tgtregion = parcobj.get_region(match.region)
-            score = match.weighted_mean_of_second
+            score = match['input weighted mean']
             srcregion._add_related_region(tgtregion, score)
             num_new_relations += 1
         logger.info(

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -963,7 +963,15 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                                 centroid=tuple(np.array(position).round(2)),
                                 volume=vol,
                                 fragment=frag,
-                                map_value=value
+                                map_value=value,
+                                result=CompareMapsResult(
+                                    intersection_over_union=None,
+                                    intersection_over_first=None,
+                                    intersection_over_second=None,
+                                    correlation=None,
+                                    weighted_mean_of_first=None,
+                                    weighted_mean_of_second=None,
+                                )
                             )
                         )
                 return assignments
@@ -990,7 +998,15 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                                 centroid=tuple(pt),
                                 volume=vol,
                                 fragment=frag,
-                                map_value=value
+                                map_value=value,
+                                result=CompareMapsResult(
+                                    intersection_over_union=None,
+                                    intersection_over_first=None,
+                                    intersection_over_second=None,
+                                    correlation=None,
+                                    weighted_mean_of_first=None,
+                                    weighted_mean_of_second=None,
+                                )
                             )
                         )
             else:
@@ -1005,10 +1021,25 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                 # build niftiimage with the Gaussian blob,
                 # then recurse into this method with the image input
                 W = Nifti1Image(dataobj=kernel, affine=np.dot(self.affine, shift))
-                for entry in self.assign(W, lower_threshold=lower_threshold):
-                    entry.input_structure = pointindex
-                    entry.centroid = tuple(pt)
-                    assignments.append(entry)
+                entries = self.assign(W, lower_threshold=lower_threshold)
+                for _, entry in entries.iterrows():
+                    assignments.append(
+                        MapAssignment(
+                            input_structure=pointindex,
+                            centroid=tuple(pt),
+                            volume=entry["volume"],
+                            fragment=entry["fragment"],
+                            map_value=entry["map value"],
+                            result=CompareMapsResult(
+                                intersection_over_union=entry["intersection over union"],
+                                intersection_over_first=entry["map containedness"],
+                                intersection_over_second=entry["input containedness"],
+                                correlation=entry["correlation"],
+                                weighted_mean_of_first=entry["map weighted mean"],
+                                weighted_mean_of_second=entry["input weighted mean"],
+                            )
+                        )
+                    )
         return assignments
 
     def _assign_image(
@@ -1110,7 +1141,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
             raise NotImplementedError("Cannot only assign labelled maps.")
         # Compress the map to a single-volume labelled parcellation if source has multiple volumes
         if len(srcmap.volumes) > 1 or len(self.fragments) > 1:
-            pass  #srcmap = srcmap.compress()
+            srcmap = srcmap.compress()
         assignments = []
         N = len(srcmap.regions)
         M = len(self.regions)
@@ -1238,11 +1269,11 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         other_map = parcobj.get_map(space=self.space, maptype='statistical')
         assignment = other_map.assign(self)
         num_new_relations = 0
-        for i, match in assignment.iterrows():
-            srclabel = match['input structure']
+        for _, match in assignment.iterrows():
+            srclabel = match.input_structure
             srcregion = self.get_region(label=srclabel)
             tgtregion = parcobj.get_region(match.region)
-            score = match['input weighted mean']
+            score = match.weighted_mean_of_second
             srcregion._add_related_region(tgtregion, score)
             num_new_relations += 1
         logger.info(

--- a/siibra/volumes/sparsemap.py
+++ b/siibra/volumes/sparsemap.py
@@ -15,7 +15,7 @@
 """Represents lists of probabilistic brain region maps."""
 from . import parcellationmap, volume as _volume
 
-from ..commons import MapIndex, logger, iterate_connected_components, siibra_tqdm
+from ..commons import MapIndex, logger, iterate_connected_components, siibra_tqdm, CompareMapsResult
 from ..locations import boundingbox
 from ..retrieval import cache
 from ..retrieval.repositories import ZipfileConnector, GitlabConnector
@@ -441,7 +441,13 @@ class SparseMap(parcellationmap.Map):
                 for volume, value in spind.probs[voxel].items()
             )
 
-    def _assign_image(self, queryimg: Nifti1Image, minsize_voxel: int, lower_threshold: float, split_components: bool = True) -> List[parcellationmap.AssignImageResult]:
+    def _assign_image(
+        self,
+        queryimg: Nifti1Image,
+        minsize_voxel: int,
+        lower_threshold: float,
+        split_components: bool = True
+    ) -> List[parcellationmap.MapAssignment]:
         """
         Assign an image volume to this parcellation map.
 
@@ -495,9 +501,10 @@ class SparseMap(parcellationmap.Map):
 
             for volume in siibra_tqdm(
                 range(len(self)),
-                desc=f"Assigning structure #{mode} to {len(self)} sparse maps",
+                desc=f"Assigning structure to {len(self)} sparse maps",
                 total=len(self),
-                unit=" map"
+                unit=" map",
+                leave=False
             ):
                 bbox1 = boundingbox.BoundingBox(
                     self.sparse_index.bboxes[volume]["minpoint"],
@@ -550,19 +557,23 @@ class SparseMap(parcellationmap.Map):
 
                 maxval = v1.max()
 
+                result = CompareMapsResult(
+                    intersection_over_union=iou,
+                    intersection_over_first=intersection / (v1 > 0).sum(),
+                    intersection_over_second=intersection / (v2 > 0).sum(),
+                    correlation=rho,
+                    weighted_mean_of_first=np.sum(v1 * v2) / np.sum(v2),
+                    weighted_mean_of_second=np.sum(v1 * v2) / np.sum(v1)
+                )
+
                 assignments.append(
-                    parcellationmap.AssignImageResult(
+                    parcellationmap.MapAssignment(
                         input_structure=mode,
                         centroid=tuple(position.round(2)),
                         volume=volume,
                         fragment=None,
                         map_value=maxval,
-                        intersection_over_union=iou,
-                        intersection_over_first=intersection / (v1 > 0).sum(),
-                        intersection_over_second=intersection / (v2 > 0).sum(),
-                        correlation=rho,
-                        weighted_mean_of_first=np.sum(v1 * v2) / np.sum(v2),
-                        weighted_mean_of_second=np.sum(v1 * v2) / np.sum(v1)
+                        result=result
                     )
                 )
 

--- a/test/volumes/test_parcellationmap.py
+++ b/test/volumes/test_parcellationmap.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from siibra.volumes.parcellationmap import Map, space, parcellation, MapType, MapIndex, ExcessiveArgumentException, InsufficientArgumentException, ConflictingArgumentException, NonUniqueIndexError
+from siibra.volumes.parcellationmap import Map, _space, parcellation, MapType, MapIndex, ExcessiveArgumentException, InsufficientArgumentException, ConflictingArgumentException, NonUniqueIndexError
 from siibra.commons import Species
 from siibra.core.region import Region
 from uuid import uuid4
@@ -95,8 +95,8 @@ class TestMap(unittest.TestCase):
 
         self.map = TestMap.get_instance(space_spec=set_space_spec)
 
-        with patch.object(space.Space, 'get_instance') as mock_get_instance:
-            return_space = space.Space(None, "Returned Space", species=Species.HOMO_SAPIENS) if return_space_flag else None
+        with patch.object(_space.Space, 'get_instance') as mock_get_instance:
+            return_space = _space.Space(None, "Returned Space", species=Species.HOMO_SAPIENS) if return_space_flag else None
             mock_get_instance.return_value = return_space
 
             actual_returned_space = self.map.space


### PR DESCRIPTION
This PR was made to be strictly additive and it is based on https://github.com/FZJ-INM1-BDA/siibra-python/pull/413.
The code to test can be found in examples/05_anatomical_assignment/003_custom_parcellation.py.

To discuss:
- If a feature type have been queried before the relation computation, the second call ignores the relations (the same issue was present in #413). Therefore, the instances are cleaned in the example before the second query. Ideally, this should not be necessary.
- How should the relations be exported for later use?
- siibra should be able to create reconfiguration files for custom maps to avoid repetition on the user side. (IMO)