### PR TITLE
Hide dataframe property from InstanceTables for classes

### DIFF
--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -101,7 +101,10 @@ class InstanceTable(Generic[T], Iterable):
 
     def __dir__(self) -> Iterable[str]:
         """List of all object keys in the registry"""
-        return ["dataframe"] + list(self._elements.keys())
+        if isinstance(self[0], type):
+            return list(self._elements.keys())
+        else:    
+            return ["dataframe"] + list(self._elements.keys())
 
     def __str__(self) -> str:
         if len(self) > 0:


### PR DESCRIPTION
Feature categories utilize `InstanceTable` as a class table to simplify querying different modalities that fit into a semantic category. `dataframe` property of  `InstanceTable`s is only useful when there are instances within. Therefore, this will be hidden now for features, that is, `siibra.features.cellular.<TAB>` will not show `dataframe`, nor should it.