### PR TITLE
Labelled maps with multiple volumes can be fetched wo args as a joint volume

### DIFF
--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -57,6 +57,8 @@ class ConflictingArgumentException(ValueError): pass
 class NonUniqueIndexError(RuntimeError): pass
 
 
+class NoVolumeFound(RuntimeError): pass
+
 @dataclass
 class Assignment:
     input_structure: int
@@ -419,7 +421,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                     aggregated_volume[regionmap.get_fdata() > 0] = regionlabel
                 return Nifti1Image(aggregated_volume, affine=template.affine)
             else:
-                raise RuntimeError("Map provides no volumes.")
+                raise NoVolumeFound("Map provides no volumes.")
 
         kwargs_fragment = kwargs.pop("fragment", None)
         if kwargs_fragment is not None:

--- a/test/volumes/test_parcellationmap.py
+++ b/test/volumes/test_parcellationmap.py
@@ -1,6 +1,10 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from siibra.volumes.parcellationmap import Map, space, parcellation, MapType, MapIndex, ExcessiveArgumentException, InsufficientArgumentException, ConflictingArgumentException, NonUniqueIndexError
+from siibra.volumes.parcellationmap import (
+    Map, space, parcellation, MapType, MapIndex, ExcessiveArgumentException,
+    InsufficientArgumentException, ConflictingArgumentException,
+    NonUniqueIndexError, NoVolumeFound
+)
 from siibra.commons import Species
 from siibra.core.region import Region
 from uuid import uuid4
@@ -265,7 +269,7 @@ class TestMap(unittest.TestCase):
         region = region_kwarg or (region_index_arg if isinstance(region_index_arg, (str, Region)) else None)
 
         if len_arg == 0 and len(volumes) != 1:
-            expected_error = InsufficientArgumentException
+            expected_error = NoVolumeFound
         elif len_arg > 1:
             expected_error = ExcessiveArgumentException
         elif (


### PR DESCRIPTION
The following code snippet raised `InsufficientArgumentException` previously. This PR allows fetching such maps when no argument has been provided in `fetch`.
```python
import siibra
mp = siibra.get_map(parcellation='julich 2.9', space='bigbrain')
img = mp.fetch()
```