### PR TITLE
Connectivity as compound feature

### DIFF
--- a/e2e/features/activity_timeseries/test_activity_timeseries.py
+++ b/e2e/features/activity_timeseries/test_activity_timeseries.py
@@ -27,9 +27,9 @@ def test_timeseries_get_table():
     assert len(features) > 0
     for f in features:
         assert isinstance(f, RegionalBOLD)
-        assert len(f.subjects) > 0
-        assert all(isinstance(subject, str) for subject in f.subjects)
-        for subject in f.subjects:
+        assert len(f.table_keys) > 0
+        assert all(isinstance(subject, str) for subject in f.table_keys)
+        for subject in f.table_keys:
             f.get_table(subject)
 
 

--- a/e2e/features/activity_timeseries/test_activity_timeseries.py
+++ b/e2e/features/activity_timeseries/test_activity_timeseries.py
@@ -25,18 +25,19 @@ def test_feature_unique():
 def test_timeseries_get_table():
     features: List["RegionalBOLD"] = siibra.features.get(jba_29, "bold")
     assert len(features) > 0
-    for f in features:
-        assert isinstance(f, RegionalBOLD)
-        assert len(f.table_keys) > 0
-        assert all(isinstance(subject, str) for subject in f.table_keys)
-        for subject in f.table_keys:
-            f.get_table(subject)
+    for cf in features:
+        assert cf.subfeature_type == RegionalBOLD
+        assert len(cf) > 0
+        assert all(isinstance(fi.table_keys, str) for fi in cf)
+        _ = cf.data
+        for fi in cf:
+            _ = fi.data
 
 
 args = [(jba_29, "RegionalBOLD"), (jba_29, RegionalBOLD)]
 
 
 @pytest.mark.parametrize("concept,query_arg", args)
-def test_get_connectivity(concept, query_arg):
+def test_get_bold(concept, query_arg):
     features: List["RegionalBOLD"] = siibra.features.get(concept, query_arg)
-    assert len(features) > 0, f"Expecting some features exist, but none exist."
+    assert len(features) > 0, "Expecting some features exist, but none exist."

--- a/e2e/features/activity_timeseries/test_activity_timeseries.py
+++ b/e2e/features/activity_timeseries/test_activity_timeseries.py
@@ -2,6 +2,7 @@ import siibra
 import pytest
 from typing import List
 
+from siibra.features.feature import CompoundFeature
 from siibra.features.tabular.regional_timeseries_activity import RegionalBOLD
 from e2e.util import check_duplicate
 
@@ -28,7 +29,6 @@ def test_timeseries_get_table():
     for cf in features:
         assert cf.subfeature_type == RegionalBOLD
         assert len(cf) > 0
-        assert all(isinstance(fi.table_keys, str) for fi in cf)
         _ = cf.data
         for fi in cf:
             _ = fi.data
@@ -39,5 +39,6 @@ args = [(jba_29, "RegionalBOLD"), (jba_29, RegionalBOLD)]
 
 @pytest.mark.parametrize("concept,query_arg", args)
 def test_get_bold(concept, query_arg):
-    features: List["RegionalBOLD"] = siibra.features.get(concept, query_arg)
+    features: List["CompoundFeature"] = siibra.features.get(concept, query_arg)
     assert len(features) > 0, "Expecting some features exist, but none exist."
+    assert all(len(cf) for cf in features > 0), "Expecting some subfeatures exist, but none exist."

--- a/e2e/features/connectivity/test_connectivity.py
+++ b/e2e/features/connectivity/test_connectivity.py
@@ -27,11 +27,11 @@ def test_feature_unique():
 @pytest.mark.parametrize("f", features)
 def test_connectivity_get_matrix(f: RegionalConnectivity):
     assert isinstance(f, RegionalConnectivity)
-    assert len(f.subjects) > 0
-    assert all(isinstance(subject, str) for subject in f.subjects)
+    assert len(f.matrix_keys) > 0
+    assert all(isinstance(subject, str) for subject in f.matrix_keys)
     matrix_df = f.get_matrix()
     assert all(matrix_df.index[i] == r for i, r in enumerate(matrix_df.columns))
-    for subject in f.subjects:
+    for subject in f.matrix_keys:
         matrix_df = f.get_matrix(subject)
         assert all(matrix_df.index[i] == r for i, r in enumerate(matrix_df.columns))
 
@@ -58,7 +58,7 @@ def test_copy_is_returned():
     feat: RegionalConnectivity = features[0]
 
     # retrieve matrix
-    matrix = feat.get_matrix(feat.subjects[0])
+    matrix = feat.get_matrix(feat.matrix_keys[0])
 
     # ensure new val to be put is different from prev val
     prev_val = matrix.iloc[0, 0]
@@ -67,5 +67,5 @@ def test_copy_is_returned():
     matrix.iloc[0, 0] = new_val
 
     # retrieve matrix again
-    matrix_again = feat.get_matrix(feat.subjects[0])
+    matrix_again = feat.get_matrix(feat.matrix_keys[0])
     assert matrix_again.iloc[0, 0] == prev_val

--- a/examples/03_data_features/006_connectivity_matrices.py
+++ b/examples/03_data_features/006_connectivity_matrices.py
@@ -45,10 +45,11 @@ print(f"Found {len(features)} streamline count matrices.")
 # Typically, connectivity features provide a range of region-to-region
 # connectivity matrices for different files from an imaging cohort. In most
 # cases, these correspond to subjects, like in this example.
-conn = features[0]
-print(f"Connectivity features reflects {conn.modality} of {conn.cohort} cohort.")
-print(conn.name)
-print("\n" + conn.description)
+for f in features:
+    print(f.name)
+    print(f.description + "\n")
+    if f.cohort == "HCP":  # and let us select the HCP cohort
+        conn = f
 
 # Subjects are encoded via anonymized ids:
 print([f.matrix_keys for f in conn])

--- a/examples/03_data_features/006_connectivity_matrices.py
+++ b/examples/03_data_features/006_connectivity_matrices.py
@@ -29,7 +29,7 @@ import siibra
 
 # %%
 # We start by selecting an atlas parcellation.
-jubrain = siibra.parcellations.get("julich")
+jubrain = siibra.parcellations.get("julich 2.9")
 
 # %%
 # The matrices are queried as expected, using `siibra.features.get`,
@@ -64,8 +64,8 @@ matrix
 
 # %%
 # Alternatively, we can visualize the matrix using plot() method
-# for each subject
-conn.plot(subject)
+# for each subject. The averaged matrix over all is stored under the key "mean".
+conn.plot("mean")
 
 # %%
 # If interested in the profile of a region we can simply plot by
@@ -76,7 +76,7 @@ conn.plot(subject, regions="hoc1 left", backend='plotly')
 # key or setting it to `None`. Also, the matrix can be displayed by specifiying
 # a list of regions.
 selected_regions = conn[subject].regions[0:30]
-conn.plot(regions=selected_regions, reorder=True, cmap="magma") 
+conn.plot(regions=selected_regions, reorder=True, cmap="magma")
 
 # %%
 # We can create a 3D visualization of the connectivity using

--- a/examples/03_data_features/006_connectivity_matrices.py
+++ b/examples/03_data_features/006_connectivity_matrices.py
@@ -29,7 +29,7 @@ import siibra
 
 # %%
 # We start by selecting an atlas parcellation.
-jubrain = siibra.parcellations.get("julich 2.9")
+jubrain = siibra.parcellations.get("julich")
 
 # %%
 # The matrices are queried as expected, using `siibra.features.get`,

--- a/examples/03_data_features/006_connectivity_matrices.py
+++ b/examples/03_data_features/006_connectivity_matrices.py
@@ -43,38 +43,40 @@ print(f"Found {len(features)} streamline count matrices.")
 # expressing structural connectivity in the form of numbers of streamlines
 # connecting pairs of brain regions as estimated from tractography on diffusion imaging.
 # Typically, connectivity features provide a range of region-to-region
-# connectivity matrices for different subjects from an imaging cohort.
+# connectivity matrices for different files from an imaging cohort. In most
+# cases, these correspond to subjects, like in this example.
 conn = features[0]
 print(f"Connectivity features reflects {conn.modality} of {conn.cohort} cohort.")
 print(conn.name)
 print("\n" + conn.description)
 
 # Subjects are encoded via anonymized ids:
-print([f.subjects for f in conn])
+print([f.matrix_keys for f in conn])
 subject = '188'  # let's select subject 188
 
 # %%
 # The connectivity matrices are provided as pandas DataFrames,
 # with region objects as index.
-average_matrix = conn.data
 matrix = conn[subject].data
 matrix
+
+# You can also obtain the average by `average_matrix = conn.data`.
 
 # %%
 # Alternatively, we can visualize the matrix using plot() method
 # for each subject
-conn[subject].plot()
+conn.plot(subject)
 
 # %%
-# if we are interested in the profile of a region we can plot by
-conn[subject].plot(region="Hoc1 left", backend='plotly')
+# If interested in the profile of a region we can simply plot by
+conn.plot(subject, regions="hoc1 left", backend='plotly')
 
 # %%
-# The average matrix across all subjects can be displayed by leaving out subjects
-# or setting it to `None`. Also, the matrix can be displayed by specifiying
+# The average matrix across all subjects can be displayed by leaving out matrix
+# key or setting it to `None`. Also, the matrix can be displayed by specifiying
 # a list of regions.
 selected_regions = conn[subject].regions[0:30]
-conn[subject].plot_matrix(regions=selected_regions, reorder=True, cmap="magma")
+conn.plot(regions=selected_regions, reorder=True, cmap="magma") 
 
 # %%
 # We can create a 3D visualization of the connectivity using
@@ -83,9 +85,8 @@ conn[subject].plot_matrix(regions=selected_regions, reorder=True, cmap="magma")
 # the anatomical space for each region (or "node") of the connectivity matrix.
 node_coords = conn[subject].compute_centroids('mni152')
 
-
 # %%
-# Now we can plot the structural connectome.
+# Now, using nilearn, we can also plot the structural connectome.
 view = plotting.plot_connectome(
     adjacency_matrix=matrix,
     node_coords=node_coords,

--- a/examples/03_data_features/006_connectivity_matrices.py
+++ b/examples/03_data_features/006_connectivity_matrices.py
@@ -50,35 +50,38 @@ print(conn.name)
 print("\n" + conn.description)
 
 # Subjects are encoded via anonymized ids:
-print(conn.subjects)
-
+print([f.subjects for f in conn])
+subject = '188'  # let's select subject 188
 
 # %%
 # The connectivity matrices are provided as pandas DataFrames,
 # with region objects as index.
-subject = conn.subjects[0]
-matrix = conn.get_matrix(subject)
+average_matrix = conn.data
+matrix = conn[subject].data
 matrix
 
+# %%
+# Alternatively, we can visualize the matrix using plot() method
+# for each subject
+conn[subject].plot()
 
 # %%
-# Alternatively, we can visualize the matrix using plot_matrix() method
-conn.plot_matrix(subject=conn.subjects[0])
-
+# if we are interested in the profile of a region we can plot by
+conn[subject].plot(region="Hoc1 left", backend='plotly')
 
 # %%
 # The average matrix across all subjects can be displayed by leaving out subjects
 # or setting it to `None`. Also, the matrix can be displayed by specifiying
 # a list of regions.
-selected_regions = conn.regions[0:30]
-conn.plot_matrix(regions=selected_regions, reorder=True, cmap="magma")
+selected_regions = conn[subject].regions[0:30]
+conn[subject].plot_matrix(regions=selected_regions, reorder=True, cmap="magma")
 
 # %%
 # We can create a 3D visualization of the connectivity using
 # the plotting module of `nilearn <https://nilearn.github.io>`_.
 # To do so, we need to provide centroids in
 # the anatomical space for each region (or "node") of the connectivity matrix.
-node_coords = conn.compute_centroids('mni152')
+node_coords = conn[subject].compute_centroids('mni152')
 
 
 # %%

--- a/examples/03_data_features/008_functional_timeseries.py
+++ b/examples/03_data_features/008_functional_timeseries.py
@@ -27,7 +27,7 @@ import siibra
 
 # %%
 # We start by selecting an atlas parcellation.
-jubrain = siibra.parcellations.get("julich 2.9")
+jubrain = siibra.parcellations.get("julich")
 
 # %%
 # The matrices are queried as expected, using `siibra.features.get`,
@@ -43,16 +43,17 @@ print(f"RegionalBOLD features reflects {bold.modality} of {bold.cohort} cohort."
 print(bold.name)
 print("\n" + bold.description)
 
-# Subjects are encoded via anonymized ids:
-print(bold.subjects)
+# subjects are encoded via anonymized ids:
+print([f.table_keys for f in bold])
+subject = '188'  # let's select subject 188
+print(bold[subject].name)
 
 
 # %%
 # The parcellation-based functional data are provided as pandas DataFrames
 # with region objects as columns and indices as time step.
-subject = bold.subjects[0]
-table = bold.get_table(subject)
-print(f"Timestep: {bold.timestep}")
+table = bold[subject].data
+print(f"Timestep: {bold[subject].timestep}")
 table[jubrain.get_region("hOc3v left")]
 
 # %%
@@ -65,7 +66,9 @@ selected_regions = [
     'Area 7A (SPL) left', 'Area 7A (SPL) right', 'CA1 (Hippocampus) left',
     'CA1 (Hippocampus) right', 'CA1 (Hippocampus) left', 'CA1 (Hippocampus) right'
 ]
-bold.plot_carpet(subject=bold.subjects[0], regions=selected_regions)
+bold.plot_carpet(subject, regions=selected_regions)
 # %%
 # Alternatively, we can visualize the mean signal strength per region:
-bold.plot(subject=bold.subjects[0], regions=selected_regions)
+bold.plot(subject, regions=selected_regions)
+
+# %%

--- a/examples/03_data_features/008_functional_timeseries.py
+++ b/examples/03_data_features/008_functional_timeseries.py
@@ -66,9 +66,7 @@ selected_regions = [
     'Area 7A (SPL) left', 'Area 7A (SPL) right', 'CA1 (Hippocampus) left',
     'CA1 (Hippocampus) right', 'CA1 (Hippocampus) left', 'CA1 (Hippocampus) right'
 ]
-bold.plot_carpet(subject, regions=selected_regions)
+bold[subject].plot_carpet(regions=selected_regions)
 # %%
 # Alternatively, we can visualize the mean signal strength per region:
 bold.plot(subject, regions=selected_regions)
-
-# %%

--- a/examples/03_data_features/008_functional_timeseries.py
+++ b/examples/03_data_features/008_functional_timeseries.py
@@ -1,0 +1,71 @@
+# Copyright 2018-2021
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Parcellation-based functional data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`siibra` provides access to parcellation-averaged functional data such as
+blood-oxygen-level-dependent (BOLD) signals.
+"""
+
+# %%
+import siibra
+# sphinx_gallery_thumbnail_number = 1
+
+# %%
+# We start by selecting an atlas parcellation.
+jubrain = siibra.parcellations.get("julich 2.9")
+
+# %%
+# The matrices are queried as expected, using `siibra.features.get`,
+# passing the parcellation as a concept.
+# Here, we query for structural connectivity matrices.
+features = siibra.features.get(jubrain, siibra.features.functional.RegionalBOLD)
+print(f"Found {len(features)} parcellation-based BOLD signals for {jubrain}.")
+
+# %%
+# We fetch the first result, which is a specific `RegionalBOLD` object.
+bold = features[0]
+print(f"RegionalBOLD features reflects {bold.modality} of {bold.cohort} cohort.")
+print(bold.name)
+print("\n" + bold.description)
+
+# Subjects are encoded via anonymized ids:
+print(bold.subjects)
+
+
+# %%
+# The parcellation-based functional data are provided as pandas DataFrames
+# with region objects as columns and indices as time step.
+subject = bold.subjects[0]
+table = bold.get_table(subject)
+print(f"Timestep: {bold.timestep}")
+table[jubrain.get_region("hOc3v left")]
+
+# %%
+# We can visualize the signal strength per region by time via a carpet plot.
+# In fact, `plot_carpet` method can take a list of regions to display the
+# data for selected regions only.
+selected_regions = [
+    'SF (Amygdala) left', 'SF (Amygdala) right', 'Area Ph2 (PhG) left',
+    'Area Ph2 (PhG) right', 'Area Fo4 (OFC) left', 'Area Fo4 (OFC) right',
+    'Area 7A (SPL) left', 'Area 7A (SPL) right', 'CA1 (Hippocampus) left',
+    'CA1 (Hippocampus) right', 'CA1 (Hippocampus) left', 'CA1 (Hippocampus) right'
+]
+bold.plot_carpet(subject=bold.subjects[0], regions=selected_regions)
+# %%
+# Alternatively, we can visualize the mean signal strength per region:
+bold.plot(subject=bold.subjects[0], regions=selected_regions)

--- a/siibra/configuration/configuration.py
+++ b/siibra/configuration/configuration.py
@@ -167,7 +167,10 @@ class Configuration:
         ):
             # filename is added to allow Factory creating reasonable default object identifiers\
             obj = Factory.from_json(dict(loader.data, **{'filename': fname}))
-            result.append(obj)
+            if isinstance(obj, list):
+                result.extend(obj)
+            else:
+                result.append(obj)
 
         return result
 

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -458,6 +458,14 @@ class Factory:
 
     @classmethod
     def build_activity_timeseries(cls, spec):
+        files = spec.pop("files", {})
+        if len(files) > 1:
+            timeseries_by_file = []
+            for fkey, file in files.items():
+                spec['files'] = {fkey: file}
+                timeseries_by_file.append(cls.build_activity_timeseries(spec))
+            return timeseries_by_file
+
         modality = spec["modality"]
         kwargs = {
             "cohort": spec["cohort"],
@@ -465,7 +473,7 @@ class Factory:
             "regions": spec["regions"],
             "connector": cls.extract_connector(spec),
             "decode_func": cls.extract_decoder(spec),
-            "files": spec.get("files", {}),
+            "files": files,
             "anchor": cls.extract_anchor(spec),
             "description": spec.get("description", ""),
             "datasets": cls.extract_datasets(spec),

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -423,7 +423,8 @@ class Factory:
     def build_connectivity_matrix(cls, spec):
         files = spec.pop("files", {})
         if len(files) > 1:
-            conn_by_file = []
+            spec['files'] = {"mean": list(files.values())}
+            conn_by_file = [cls.build_connectivity_matrix(spec)]
             for fkey, file in files.items():
                 spec['files'] = {fkey: file}
                 conn_by_file.append(cls.build_connectivity_matrix(spec))
@@ -460,7 +461,8 @@ class Factory:
     def build_activity_timeseries(cls, spec):
         files = spec.pop("files", {})
         if len(files) > 1:
-            timeseries_by_file = []
+            spec['files'] = {"mean": list(files.values())}
+            timeseries_by_file = [cls.build_activity_timeseries(spec)]
             for fkey, file in files.items():
                 spec['files'] = {fkey: file}
                 timeseries_by_file.append(cls.build_activity_timeseries(spec))

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -421,6 +421,14 @@ class Factory:
 
     @classmethod
     def build_connectivity_matrix(cls, spec):
+        files = spec.pop("files", {})
+        if len(files) > 1:
+            conn_by_file = []
+            for fkey, file in files.items():
+                spec['files'] = {fkey: file}
+                conn_by_file.append(cls.build_connectivity_matrix(spec))
+            return conn_by_file
+
         modality = spec["modality"]
         kwargs = {
             "cohort": spec.get("cohort", ""),
@@ -428,7 +436,7 @@ class Factory:
             "regions": spec["regions"],
             "connector": cls.extract_connector(spec),
             "decode_func": cls.extract_decoder(spec),
-            "files": spec.get("files", {}),
+            "files": files,
             "anchor": cls.extract_anchor(spec),
             "description": spec.get("description", ""),
             "datasets": cls.extract_datasets(spec),

--- a/siibra/features/connectivity/regional_connectivity.py
+++ b/siibra/features/connectivity/regional_connectivity.py
@@ -130,19 +130,14 @@ class RegionalConnectivity(Feature):
             A square matrix with region names as the column and row names.
         """
         assert len(self) > 0
-        if (matrix_key is None) and (len(self) > 1):
-            # multiple matrices available, but no matrix_key given - return mean matrix
-            logger.info(
-                f"No matrix_key name supplied, returning mean connectivity across {len(self)} matrix keys. "
-                "You might alternatively specify an individual matrix_key."
-            )
+        if matrix_key == "mean":
             if "mean" not in self._matrices:
                 all_arrays = [
                     self._connector.get(fname, decode_func=self._decode_func)
                     for fname in siibra_tqdm(
-                        self._files.values(),
-                        total=len(self),
-                        desc=f"Averaging {len(self)} connectivity matrices"
+                        self._files["mean"],
+                        total=len(self._files["mean"]),
+                        desc="Averaging connectivity matrices"
                     )
                 ]
                 self._matrices['mean'] = self._arraylike_to_dataframe(np.stack(all_arrays).mean(0))

--- a/siibra/features/connectivity/regional_connectivity.py
+++ b/siibra/features/connectivity/regional_connectivity.py
@@ -316,9 +316,20 @@ class RegionalConnectivity(Feature):
                 "x": kwargs.get("x", profile.data.columns[0]),
                 "y": kwargs.get("y", [r.name for r in profile.data.index]),
                 "log_x": logscale,
-                "labels": {"index": "Regions"},
-                "color_continuous_scale": "jet"
+                "labels": {"y": " ", "x": ""},
+                "color_continuous_scale": "jet",
+                "width": 600, "height": 3800
             })
+            fig = profile.data.plot(*args, backend=backend, **kwargs)
+            fig.update_layout({
+                "font": dict(size=9),
+                "yaxis": {"autorange": "reversed"},
+                "coloraxis": {"colorbar": {
+                    "orientation": "h", "title": "", "xpad": 0, "ypad": 10
+                }},
+                "margin": dict(l=0, r=0, b=0, t=0, pad=0)
+            })
+            return fig
         return profile.plot(*args, backend=backend, **kwargs)
 
     def __len__(self):

--- a/siibra/features/connectivity/regional_connectivity.py
+++ b/siibra/features/connectivity/regional_connectivity.py
@@ -102,7 +102,8 @@ class RegionalConnectivity(Feature):
     @property
     def name(self):
         supername = super().name
-        return f"{supername} with cohort {self.cohort}"
+        postfix = f" and paradigm {self.paradigm}" if hasattr('paradigm') else ""
+        return f"{supername} with cohort {self.cohort}" + postfix
 
     @property
     def data(self):

--- a/siibra/features/connectivity/regional_connectivity.py
+++ b/siibra/features/connectivity/regional_connectivity.py
@@ -68,7 +68,7 @@ class RegionalConnectivity(Feature):
         decode_func: function
             Function to convert the bytestream of a loaded file into an array
         files: dict
-            A dictionary linking names of matrices (typically subject ids)
+            A dictionary linking names of matrices (typically matrix_key ids)
             to the relative filenames of the data array(s) in the repository connector.
         anchor: AnatomicalAnchor
             anatomical localization of the matrix, expected to encode the parcellation
@@ -93,30 +93,36 @@ class RegionalConnectivity(Feature):
         self._matrices = {}
 
     @property
-    def subjects(self):
+    def matrix_keys(self):
         """
-        Returns the subject identifiers for which matrices are available.
+        Returns the matrix_key identifiers for which matrices are available.
         """
         return list(self._files.keys())
 
     @property
+    def _filter_key(self):
+        assert len(self) == 1, "Filter key can only be made from one `matrix_key`."
+        return self.matrix_keys[0]
+
+    @property
     def name(self):
         supername = super().name
-        postfix = f" and paradigm {self.paradigm}" if hasattr('paradigm') else ""
-        return f"{supername} with cohort {self.cohort}" + postfix
+        postfix = f" and paradigm {self.paradigm}" if hasattr(self, 'paradigm') else ""
+        return f"{supername} with cohort {self.cohort}" + postfix + f" - {self.matrix_keys[0]}"
 
     @property
     def data(self):
+        assert len(self) == 1, "Data propery requires singular file association. Please use `get_matrix` instead."
         return self.get_matrix(self._filter_key)
 
-    def get_matrix(self, subject: str = None):
+    def get_matrix(self, matrix_key: str = None):
         """
         Returns a matrix as a pandas dataframe.
 
         Parameters
         ----------
-        subject: str, default: None
-            Name of the subject (see ConnectivityMatrix.subjects for available names).
+        matrix_key: str, default: None
+            Name of the matrix_key (see ConnectivityMatrix.matrix_keys for available names).
             If None, the mean is taken in case of multiple available matrices.
         Returns
         -------
@@ -124,11 +130,11 @@ class RegionalConnectivity(Feature):
             A square matrix with region names as the column and row names.
         """
         assert len(self) > 0
-        if (subject is None) and (len(self) > 1):
-            # multiple matrices available, but no subject given - return mean matrix
+        if (matrix_key is None) and (len(self) > 1):
+            # multiple matrices available, but no matrix_key given - return mean matrix
             logger.info(
-                f"No subject name supplied, returning mean connectivity across {len(self)} subjects. "
-                "You might alternatively specify an individual subject."
+                f"No matrix_key name supplied, returning mean connectivity across {len(self)} matrix keys. "
+                "You might alternatively specify an individual matrix_key."
             )
             if "mean" not in self._matrices:
                 all_arrays = [
@@ -141,16 +147,16 @@ class RegionalConnectivity(Feature):
                 ]
                 self._matrices['mean'] = self._arraylike_to_dataframe(np.stack(all_arrays).mean(0))
             return self._matrices['mean'].copy()
-        if subject is None:
-            subject = next(iter(self._files.keys()))
-        if subject not in self._files:
-            raise ValueError(f"Subject name '{subject}' not known, use one of: {', '.join(self._files)}")
-        if subject not in self._matrices:
-            self._matrices[subject] = self._load_matrix(subject)
-        return self._matrices[subject].copy()
+        if matrix_key is None:
+            matrix_key = next(iter(self._files.keys()))
+        if matrix_key not in self._files:
+            raise ValueError(f"Matrix key '{matrix_key}' not known, use one of: {', '.join(self._files)}")
+        if matrix_key not in self._matrices:
+            self._matrices[matrix_key] = self._load_matrix(matrix_key)
+        return self._matrices[matrix_key].copy()
 
     def plot_matrix(
-        self, subject: str = None, regions: List[str] = None,
+        self, matrix_key: str = None, regions: List[str] = None,
         logscale: bool = False, *args, backend="nilearn", **kwargs
     ):
         """
@@ -158,8 +164,8 @@ class RegionalConnectivity(Feature):
 
         Parameters
         ----------
-        subject: str
-            Name of the subject (see ConnectivityMatrix.subjects for available names).
+        matrix_keys: str
+            Name of the matrix key (see ConnectivityMatrix.matrix_keys for available names).
             If "mean" or None is given, the mean is taken in case of multiple
             available matrices.
         regions: list[str]
@@ -173,19 +179,22 @@ class RegionalConnectivity(Feature):
             Can take all the arguments `nilearn.plotting.plot_matrix` can take. See the doc at
             https://nilearn.github.io/stable/modules/generated/nilearn.plotting.plot_matrix.html
         """
+        if matrix_key is None and len(self) == 1:
+            matrix_key = self._filter_key
+
         if regions is None:
             regions = self.regions
         indices = [self.regions.index(r) for r in regions]
-        matrix = self.get_matrix(subject=subject).iloc[indices, indices].to_numpy()  # nilearn.plotting.plot_matrix works better with a numpy array
+        matrix = self.get_matrix(matrix_key=matrix_key).iloc[indices, indices].to_numpy()  # nilearn.plotting.plot_matrix works better with a numpy array
 
         if logscale:
             matrix = np.log10(matrix)
 
         # default kwargs
-        subject_title = subject or ""
+        matrix_key_title = matrix_key or ""
         kwargs["title"] = kwargs.get(
             "title",
-            f"{subject_title} - {self.modality} in {', '.join({_.name for _ in self.anchor.regions})}"
+            f"{matrix_key_title} - {self.modality} in {', '.join({_.name for _ in self.anchor.regions})}"
         )
 
         if kwargs.get("reorder") or (backend == "nilearn"):
@@ -210,7 +219,7 @@ class RegionalConnectivity(Feature):
     def get_profile(
         self,
         region: Union[str, _region.Region],
-        subject: str = None,
+        matrix_key: str = None,
         min_connectivity: float = 0,
         max_rows: int = None,
         direction: Literal['column', 'row'] = 'column'
@@ -223,7 +232,7 @@ class RegionalConnectivity(Feature):
         Parameters
         ----------
         region: str, Region
-        subject: str, default: None
+        matrix_key: str, default: None
         min_connectivity: float, default: 0
             Regions with connectivity less than this value are discarded.
         max_rows: int, default: None
@@ -232,7 +241,7 @@ class RegionalConnectivity(Feature):
             Choose the direction of profile extraction particularly for
             non-symmetric matrices. ('column' or 'row')
         """
-        matrix = self.get_matrix(subject)
+        matrix = self.get_matrix(matrix_key)
         if direction.lower() not in ['column', 'row']:
             raise ValueError("Direction can only be 'column' or 'row'")
         if direction.lower() == 'row':
@@ -252,7 +261,7 @@ class RegionalConnectivity(Feature):
             raise ValueError(f"Region specification {region} matched more than one profile: {regions}")
         else:
             name = \
-                f"Averaged {self.modality}" if subject is None \
+                f"Averaged {self.modality}" if matrix_key is None \
                 else f"{self.modality}"
             series = matrix[regions[0]]
             last_index = len(series) - 1 if max_rows is None \
@@ -276,8 +285,8 @@ class RegionalConnectivity(Feature):
 
     def plot(
         self,
-        region: Union[str, _region.Region, List[Union[str, _region.Region]]] = None,
-        subject: str = None,
+        regions: Union[str, _region.Region, List[Union[str, _region.Region]]] = None,
+        matrix_key: str = None,
         min_connectivity: float = 0,
         max_rows: int = None,
         direction: Literal['column', 'row'] = 'column',
@@ -289,25 +298,29 @@ class RegionalConnectivity(Feature):
         """
         Parameters
         ----------
-        region : Union[str, _region.Region], None
+        regions: Union[str, _region.Region], None
             If None, returns the full connectivity matrix.
             If a region is provided, returns the profile for that region.
             If list of regions is provided, returns the matrix for the selected
             regions.
-        min_connectivity : float, default 0
-        max_rows : int, default None
-        direction : 'column' or 'row', default: 'column'
-        logscale : bool, default: False
-        backend : str, default: "matplotlib"
+        min_connectivity: float, default 0
+            Only for region profile.
+        max_rows: int, default None
+            Only for region profile.
+        direction: 'column' or 'row', default: 'column'
+            Only for matrix.
+        logscale: bool, default: False
+        backend: str, default: "matplotlib" for profiles and "nilearn" for matrices
         """
-        if region is None or isinstance(region, list):
+        if regions is None or isinstance(regions, list):
+            plot_matrix_backend = "nilearn" if backend == "matplotlib" else backend
             return self.plot_matrix(
-                subject=subject, regions=region, logscale=logscale, *args,
-                backend="nilearn" if backend == "matplotlib" else "plotly",
+                matrix_key=matrix_key, regions=regions, logscale=logscale, *args,
+                backend=plot_matrix_backend,
                 **kwargs
             )
 
-        profile = self.get_profile(region, subject, min_connectivity, max_rows, direction)
+        profile = self.get_profile(regions, matrix_key, min_connectivity, max_rows, direction)
         kwargs["kind"] = kwargs.get("kind", "barh")
         if backend == "matplotlib":
             kwargs["logx"] = kwargs.get("logx", logscale)
@@ -405,21 +418,16 @@ class RegionalConnectivity(Feature):
             raise RuntimeError("Could not decode connectivity matrix regions.")
         return df
 
-    def _load_matrix(self, subject: str):
+    def _load_matrix(self, matrix_key: str):
         """
         Extract connectivity matrix.
         """
-        assert subject in self.subjects
-        array = self._connector.get(self._files[subject], decode_func=self._decode_func)
+        assert matrix_key in self.matrix_keys
+        array = self._connector.get(self._files[matrix_key], decode_func=self._decode_func)
         nrows = array.shape[0]
         if array.shape[1] != nrows:
             raise RuntimeError(
                 f"Non-quadratic connectivity matrix {nrows}x{array.shape[1]} "
-                f"from {self._files[subject]} in {str(self._connector)}"
+                f"from {self._files[matrix_key]} in {str(self._connector)}"
             )
         return self._arraylike_to_dataframe(array)
-
-    @property
-    def _filter_key(self):
-        assert len(self) == 1
-        return self.subjects[0]

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -511,6 +511,11 @@ class CompoundFeature(Feature):
             logger.error({f.modality for f in features})
             raise NotImplementedError("Cannot compound features of different modalities.")
 
+        if hasattr(features[0], 'cohort') and len({f.cohort for f in features}) == 1:
+            self.cohort = features[0].cohort
+        if hasattr(features[0], 'paradigm') and len({f.paradigm for f in features}) == 1:
+            self.paradigm = features[0].paradigm
+
         assert not any(isinstance(f._filter_key, int) for f in features), "Filter keys cannot be integers."
         self._subfeatures = {f._filter_key: f for f in features}
 

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -557,16 +557,17 @@ class CompoundFeature(Feature):
         if self._data_cached is None:
             if "mean" in self.subfeature_keys:
                 self._data_cached = self['mean'].data
-            try:
-                self._data_cached = sum([
-                    f.data for f in siibra_tqdm(
-                        self.subfeatures, desc='Averaging', unit="subfeature"
+            else:
+                try:
+                    self._data_cached = sum([
+                        f.data for f in siibra_tqdm(
+                            self.subfeatures, desc='Averaging', unit="subfeature"
+                        )
+                    ]) / len(self)
+                except Exception:
+                    raise NotImplementedError(
+                        f"Cannot get average data for CompoundFeatures of type {self._subfeature_type}"
                     )
-                ]) / len(self)
-            except Exception:
-                raise NotImplementedError(
-                    f"Cannot get average data for CompoundFeatures of type {self._subfeature_type}"
-                )
         return self._data_cached
 
     def __iter__(self) -> Iterator['Feature']:

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -555,19 +555,19 @@ class CompoundFeature(Feature):
     @property
     def data(self):
         if self._data_cached is None:
+            if "mean" in self.subfeature_keys:
+                self._data_cached = self['mean'].data
             try:
                 self._data_cached = sum([
                     f.data for f in siibra_tqdm(
                         self.subfeatures, desc='Averaging', unit="subfeature"
                     )
                 ]) / len(self)
-                return self._data_cached
             except Exception:
                 raise NotImplementedError(
                     f"Cannot get average data for CompoundFeatures of type {self._subfeature_type}"
                 )
-        else:
-            return self._data_cached
+        return self._data_cached
 
     def __iter__(self) -> Iterator['Feature']:
         """Iterate over all subfeatures"""
@@ -700,11 +700,15 @@ class CompoundFeature(Feature):
         """
         if filter_key is not None:
             return self[filter_key].plot(*args, backend=backend, **kwargs)
-        else:
+        if "mean" in self.subfeature_keys:
             try:
-                return self.data.plot(*args, backend=backend, **kwargs)
+                return self['mean'].plot(*args, backend=backend, **kwargs)
             except Exception:
-                raise NotImplementedError(
-                    "Cannot plot average data for CompoundFeatures of type"
-                    f" {self._subfeature_type}"
-                )
+                pass
+        try:
+            return self.data.plot(*args, backend=backend, **kwargs)
+        except Exception:
+            raise NotImplementedError(
+                "Cannot plot average data for CompoundFeatures of type"
+                f" {self._subfeature_type}"
+            )

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -560,6 +560,10 @@ class CompoundFeature(Feature):
         else:
             return self._data_cached
 
+    def __iter__(self) -> Iterator['Feature']:
+        """Iterate over all subfeatures"""
+        return (f for f in self._subfeatures.values())
+
     def __len__(self):
         return len(self._subfeatures)
 

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -307,12 +307,16 @@ class Feature:
 
     @classmethod
     def _parse_featuretype(cls, feature_type: str) -> List[Type['Feature']]:
-        return [
+        ftypes = {
             feattype
             for FeatCls, feattypes in cls.SUBCLASSES.items()
             if all(w.lower() in FeatCls.__name__.lower() for w in feature_type.split())
             for feattype in feattypes
-        ]
+        }
+        if len(ftypes) > 1:
+            return [ft for ft in ftypes if getattr(ft, 'category')]
+        else:
+            return list(ftypes)
 
     @classmethod
     def livequery(cls, concept: Union[region.Region, parcellation.Parcellation, space.Space], **kwargs) -> List['Feature']:

--- a/siibra/features/tabular/regional_timeseries_activity.py
+++ b/siibra/features/tabular/regional_timeseries_activity.py
@@ -90,7 +90,8 @@ class RegionalTimeseriesActivity(tabular.Tabular):
 
     @property
     def data(self):
-        return self.get_table()
+        assert len(self) == 1, "Data propery requires singular file association. Please use `get_matrix` instead."
+        return self.get_table(self._filter_key)
 
     def get_table(self, table_key: str = None):
         """
@@ -108,19 +109,14 @@ class RegionalTimeseriesActivity(tabular.Tabular):
             A table with region names as the column and timesteps as indices.
         """
         assert len(self) > 0
-        if (table_key is None) and (len(self) > 1):
-            # multiple signal tables available, but no table_key given - return mean table
-            logger.info(
-                f"No table_key name supplied, returning mean signal table across {len(self)} table_keys. "
-                "You might alternatively specify an individual table_key."
-            )
+        if table_key == "mean":
             if "mean" not in self._tables:
                 all_arrays = [
                     self._connector.get(fname, decode_func=self._decode_func)
                     for fname in siibra_tqdm(
-                        self._files.values(),
-                        total=len(self),
-                        desc=f"Averaging {len(self)} signal tables"
+                        self._files["mean"],
+                        total=len(self._files["mean"]),
+                        desc="Averaging signal tables"
                     )
                 ]
                 self._tables['mean'] = self._array_to_dataframe(np.stack(all_arrays).mean(0))

--- a/siibra/features/tabular/regional_timeseries_activity.py
+++ b/siibra/features/tabular/regional_timeseries_activity.py
@@ -18,11 +18,10 @@ from . import tabular
 from .. import anchor as _anchor
 
 from ...commons import logger, QUIET, siibra_tqdm
-from ...core import region as _region
 from ...locations import pointset
 from ...retrieval.repositories import RepositoryConnector
 
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, List
 import pandas as pd
 import numpy as np
 
@@ -196,10 +195,56 @@ class RegionalTimeseriesActivity(tabular.Tabular):
             df = df.rename(columns=remapper)
         return df
 
-    def plot(self, subject: str = None, *args, backend="matplotlib", **kwargs):
-        table = self.get_table(subject)
+    def plot(
+        self, subject: str = None, regions: List[str] = None, *args,
+        backend="matplotlib", **kwargs
+    ):
+        """
+        Create a bar plot of averaged timeseries data per region.
+
+        Parameters
+        ----------
+        regions: str, Region
+        subject: str, default: None
+            If None, returns the subject averaged table.
+        args and kwargs:
+            takes arguments and keyword arguments for the desired plotting
+            backend.
+        """
+        if regions is None:
+            regions = self.regions
+        indices = [self.regions.index(r) for r in regions]
+        table = self.get_table(subject).iloc[:, indices]
         table.columns = [str(r) for r in table.columns]
         return table.mean().plot(kind="bar", *args, backend=backend, **kwargs)
+
+    def plot_carpet(
+        self, subject: str = None, regions: List[str] = None, *args,
+        backend="plotly", **kwargs
+    ):
+        """
+        Create a carpet plot ofthe timeseries data per region.
+
+        Parameters
+        ----------
+        regions: str, Region
+        subject: str, default: None
+            If None, returns the subject averaged table.
+        args and kwargs:
+            takes arguments and keyword arguments for `plotly.express.imshow`
+        """
+        if backend != "plotly":
+            raise NotImplementedError("Currently, carpet plot is only implemented with `plotly`.")
+        if regions is None:
+            regions = self.regions
+        indices = [self.regions.index(r) for r in regions]
+        table = self.get_table(subject).iloc[:, indices]
+        table.columns = [str(r) for r in table.columns]
+        from plotly.express import imshow
+        return imshow(
+            table.T,
+            title=f"{self.modality}" + f" for subject={subject}" if subject else ""
+        )
 
 
 class RegionalBOLD(

--- a/siibra/locations/__init__.py
+++ b/siibra/locations/__init__.py
@@ -47,6 +47,9 @@ def override_union(loc0: 'Location', loc1: 'Location') -> 'Location':
         - WholeBrain U Location = NotImplementedError
         (all operations are commutative)
     """
+    if loc0 is None or loc1 is None:
+        return loc0 or loc1
+
     if isinstance(loc0, WholeBrain) or isinstance(loc1, WholeBrain):
         raise NotImplementedError("Union of WholeBrains is not yet implemented.")
 


### PR DESCRIPTION
(This PR builds on top of https://github.com/FZJ-INM1-BDA/siibra-python/pull/441)
```python
import siibra
fts = siibra.features.get(siibra.parcellations['julich 2.9'], 'connectivity')
for f in fts:
    print(f.name)
print(fts[0][0].data.head())  # 0th subject
print(fts[0].data.head())  # average
```
Also to try:
```python
fts[0][0].plot()
```
```python
fts[0][0].plot(region=fts[0][0].regions[0], backend='plotly')
```
```python
fts[0][0].plot(region=fts[0][0].regions[:20], logscale=True, backend='plotly')
```
TODO:
- [x] choose a new matrix key property besides from `subjects` (perhaps `matrix_key`). This will enable us to digest F-Tract data with minimal effort.
- [x] Then, clean or replace the references to `subject` and `subjects`
- [x] carry the same logic to regional timeseries features like bold
- [x] Update examples
    - [x] Figure out a way to plot average matrix from compound feature

PS: This will allow the digestion of connectivity features as the other features in siibra-explorer, eliminating the need for handling specially. (caveat: the click and travel mechanism won't work.) (colors should be available from plotly json but not sure it is easy for explorer to use)