### PR TITLE
feat: add maps from nifti and label information

### DIFF
--- a/examples/02_maps_and_templates/007_adding_custom_parcellation.py
+++ b/examples/02_maps_and_templates/007_adding_custom_parcellation.py
@@ -1,0 +1,75 @@
+# Copyright 2018-2023
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Adding a custom parcellation map
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you might want to use a custom parcellation map to perform feature queries in siibra.
+This brings some challenges as we will see. For this example, we retrieve a
+freely available von Economo map in MNI space from Martijn van den Heuvel's lab.
+"""
+
+
+# %%
+import siibra
+import re  # we need this for text file parsing below
+from nilearn import plotting
+
+# %%
+# Load the custom parcellation map from the online resource. For the retrieval,
+# siibra's zipfile connector is very helpful. We can use the resulting NIfTI
+# to create a custom parcellation map inside siibra.
+
+# connect to the online zip file
+conn = siibra.retrieval.ZipfileConnector(
+    "http://www.dutchconnectomelab.nl/economo/economoMNI152volume.zip"
+)
+
+# the NIfTI file is easily retrieved:
+nifti_map = conn.get("economoMNI152volume/economoMNI152volume.nii.gz")
+
+# The text file with label mappings has a custom format.
+# We provide a simple decoder to extract the list of region/label pairs.
+decoder = lambda b: [
+    re.split(r'\s+', line)[:2]       # fields are separated by one or more whitespaces
+    for line in b.decode().split('\n')
+    if re.match(r'^\d\d\d\d', line)  # only lines starting with 4-digit labels are relevant
+]
+labels = conn.get("economoMNI152volume/economoLUT.txt", decode_func=decoder)
+
+# Now we use this to add a custom map to siibra.
+# Note that this assumes our external knowledge that the map is in MNI152 space.
+custom_map = siibra.add_nifti_map(
+    name="Von Economo Atlas",
+    nifti_map=nifti_map,
+    space_spec='mni152',
+    regionnames=[name.replace('ctx-rh-', 'right ').replace('ctx-lh-', 'left ') for _, name in labels],
+    regionlabels=[int(label) for label, _ in labels]
+)
+
+# let's plot the final map
+plotting.plot_roi(custom_map.fetch())
+
+
+# %%
+# We can already use this map to find spatial features, such as BigBrain
+# intensity profiles.
+custom_region = custom_map.parcellation.get_region('fcbm')
+profiles = siibra.features.get(
+    custom_region,
+    siibra.features.cellular.BigBrainIntensityProfile
+)
+print(f"{len(profiles)} intensity profiles found.")

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -50,6 +50,7 @@ set_ebrains_token = _EbrainsRequest.set_token
 fetch_ebrains_token = _EbrainsRequest.fetch_token
 find_regions = _parcellation.Parcellation.find_regions
 from_json = factory.Factory.from_json
+add_nifti_map = _parcellationmap.Map.from_nifti
 
 
 def __getattr__(attr: str):
@@ -152,5 +153,6 @@ def __dir__():
         "vocabularies",
         "__version__",
         "cache",
-        "warm_cache"
+        "warm_cache",
+        "add_nifti_map"
     ]

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -24,6 +24,8 @@ import pandas as pd
 from typing import Generic, Iterable, Iterator, List, TypeVar, Union, Dict
 from skimage.filters import gaussian
 from dataclasses import dataclass
+from hashlib import md5
+from uuid import UUID
 
 logger = logging.getLogger(__name__.split(os.path.extsep)[0])
 ch = logging.StreamHandler()
@@ -754,3 +756,14 @@ class Species(Enum):
 
     def __repr__(self):
         return f"{self.__class__.__name__}: {str(self)}"
+
+
+def get_uuid(string: str):
+    if isinstance(string, str):
+        b = string.encode("UTF-8")
+    elif isinstance(string, Nifti1Image):
+        b = string.to_bytes()
+    else:
+        raise ValueError(f"Cannot build uuid for parameter type {type(string)}")
+    hex_string = md5(b).hexdigest()
+    return str(UUID(hex=hex_string))

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -26,7 +26,8 @@ from ..commons import (
     create_gaussian_kernel,
     siibra_tqdm,
     Species,
-    CompareMapsResult
+    CompareMapsResult,
+    get_uuid
 )
 from ..core import concept, space, parcellation, region as _region
 from ..locations import point, pointset
@@ -80,7 +81,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         name: str,
         space_spec: dict,
         parcellation_spec: dict,
-        indices: Dict[str, Dict],
+        indices: Dict[str, List[Dict]],
         volumes: list = [],
         shortname: str = "",
         description: str = "",
@@ -1134,3 +1135,120 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                                 )
 
         return assignments
+
+    @classmethod
+    def from_nifti(
+        cls,
+        name: str,
+        nifti_map: Union[str, Nifti1Image, List[Union[str, Nifti1Image]]],
+        space_spec: Union[str, "space.Space"],
+        regionnames: List[str],
+        regionlabels: List[int],
+        parcellation_spec: Union[str, "parcellation.Parcellation"] = None
+    ) -> 'Map':
+        """
+        Add a custom labelled parcellation map to siibra from a labelled NIfTI file.
+
+        Parameters:
+        ------------
+        name: str
+            Human-readable name of the parcellation.
+        nifti_map: str, Nifti1Image, or a list of these.
+            NIfTI file destination or image with a labelled volume.
+        space_spec: str, Space
+            Specification of the reference space (space object, name, keyword, or id - e.g. 'mni152').
+        regionnames: list[str]
+            List of human-readable names of the mapped regions.
+        regionlabels: list[int]
+            List of integer labels in the nifti file corresponding to the list of regions.
+        parcellation: str or Parcellation. Optional.
+            If the related parcellation already defined or preconfigured in siibra.
+        """
+        try:
+            spaceobj = space.Space.registry().get(space_spec)
+        except Exception:
+            raise ValueError(f"No space matches '{space_spec}'.")
+
+        # providers and map indices
+        providers = []
+        for vol_idx, volume in enumerate(
+            nifti_map if isinstance(nifti_map, list) else [nifti_map]
+        ):
+            if not isinstance(volume, Nifti1Image):
+                volume = Nifti1Image.load(volume)
+            arr = np.asanyarray(volume.dataobj)
+            labels_in_volume = np.unique(arr)[1:].astype('int')
+
+            # populate region indices from given name/label lists
+            indices = dict()
+            for label, regionname in zip(regionlabels, regionnames):
+                if label not in labels_in_volume:
+                    logger.warning(
+                        f"Label {label} not mapped in the provided NIfTI volume -> "
+                        f"region '{regionname} will not be in the map."
+                    )
+                elif label in [v[0]['label'] for v in indices.values() if v[0]['volume'] == vol_idx]:
+                    logger.warning(f"Label {label} already defined in the same volume; will not map it to '{regionname}'.")
+                else:
+                    assert regionname not in indices, f"'{regionname}' must be unique in `regionnames`."
+                    indices[regionname] = [{'volume': vol_idx, 'label': label}]
+
+            # check for any remaining labels in the NIfTI volume
+            unnamed_labels = list(set(labels_in_volume) - set(regionlabels))
+            if unnamed_labels:
+                logger.warning(
+                    f"The following labels appear in the NIfTI volume {vol_idx}, but not in "
+                    f"the specified regions: {', '.join(str(l) for l in unnamed_labels)}. "
+                    "They will be removed from the nifti volume."
+                )
+                for label in unnamed_labels:
+                    arr[arr == label] = 0
+            providers.append(
+                nifti.NiftiProvider(Nifti1Image(arr, volume.affine, header=volume.header))
+            )
+
+        # parcellation
+        if parcellation_spec is None:
+            parcellation_spec = name
+        try:
+            parcobj = parcellation.Parcellation.registry().get(parcellation_spec)
+            logger.info(f"Using '{parcellation_spec}', siibra decoded the parcellation as '{parcobj}'")
+        except Exception:
+            logger.info(
+                f"Using '{parcellation_spec}', siibra could not decode the ",
+                " parcellation. Building a new parcellation."
+            )
+            # build a new parcellation
+            parcobj = parcellation.Parcellation(
+                identifier=get_uuid(','.join(regionnames)),
+                name=name,
+                species=spaceobj.species,
+                regions=list(map(_region.Region, regionnames)),
+            )
+            if parcobj.key not in list(parcellation.Parcellation.registry()):
+                parcellation.Parcellation.registry().add(parcobj.key, parcobj)
+
+        for region in siibra_tqdm(
+            indices.keys(),
+            desc="Checking if provided regions are defined in the parcellation."
+        ):
+            try:
+                _ = parcobj.get_region(region)
+            except Exception:
+                logger.warning(f"'{region}' is missing in the parcellation.")
+
+        # build the parcellation map object
+        parcmap = Map(
+            identifier=get_uuid(volume),
+            name=f"{name} map in {spaceobj.name}",
+            space_spec=spaceobj._spec,
+            parcellation_spec={'name': parcobj.name},
+            indices=indices,
+            volumes=[_volume.Volume(spaceobj._spec, providers=providers)]
+        )
+
+        # add it to siibra's registry
+        Map.registry().add(parcmap.key, parcmap)
+
+        # return the map - note that it has a pointer to the parcellation
+        return parcmap


### PR DESCRIPTION
This is meant to be a preparation for querying features with volumes. The previous iteration (https://github.com/FZJ-INM1-BDA/siibra-python/pull/442) required computation of the relations to the defined maps. With the ability to query with volumes, this computation is unnecessary.

In addition, this PR allows creating a map from multiple volumes and supplying parcellation specifications.

TODO:
- [ ] a method for adding custom parcellations.
- [ ] a method for adding custom space.
- [ ] a method to extracting these custom atlas concepts as json reconfiguration