### PR TITLE
Increase intensity profile compounding speed

### DIFF
--- a/siibra/features/anchor.py
+++ b/siibra/features/anchor.py
@@ -25,7 +25,7 @@ from ..core.space import Space
 
 from ..vocabularies import REGION_ALIASES
 
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Iterable
 
 
 class AnatomicalAnchor:
@@ -45,7 +45,7 @@ class AnatomicalAnchor:
 
         if isinstance(species, (str, Species)):
             self.species = {Species.decode(species)}
-        elif isinstance(species, list):
+        elif isinstance(species, Iterable):
             assert all(isinstance(_, Species) for _ in species)
             self.species = set(species)
         else:

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -667,6 +667,10 @@ class Compoundable(ABC):
         assert hash(index), "`_element_index` of a compoundable must be hashable."
         return index
 
+    @classmethod
+    def _merge_anchors(cls, anchors: List[_anchor.AnatomicalAnchor]):
+        return sum(anchors)
+
 
 class CompoundFeature(Feature):
     """
@@ -711,7 +715,7 @@ class CompoundFeature(Feature):
             self,
             modality=modality,
             description="\n".join({f.description for f in elements}),
-            anchor=sum([f.anchor for f in elements]),
+            anchor=self._feature_type._merge_anchors([f.anchor for f in elements]),
             datasets=list(dict.fromkeys([ds for f in elements for ds in f.datasets]))
         )
         self._queryconcept = queryconcept

--- a/siibra/features/tabular/bigbrain_intensity_profile.py
+++ b/siibra/features/tabular/bigbrain_intensity_profile.py
@@ -15,7 +15,9 @@
 
 from . import cortical_profile
 
-from ...locations import point
+from typing import List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from ...locations import point
 
 
 class BigBrainIntensityProfile(
@@ -42,7 +44,7 @@ class BigBrainIntensityProfile(
         depths: list,
         values: list,
         boundaries: list,
-        location: point.Point
+        location: 'point.Point'
     ):
         from ..anchor import AnatomicalAnchor
         anchor = AnatomicalAnchor(
@@ -67,3 +69,19 @@ class BigBrainIntensityProfile(
     @property
     def location(self):
         return self.anchor.location
+
+    @classmethod
+    def _merge_anchors(cls, anchors: List['AnatomicalAnchor']):
+        from ...locations.pointset import PointSet
+        from ...features.anchor import AnatomicalAnchor
+
+        location = PointSet(
+            [anchor.location for anchor in anchors],
+            space="BigBrain"
+        )
+        regions = {anchor._regionspec for anchor in anchors}
+        return AnatomicalAnchor(
+            location=location,
+            region=", ".join(regions),
+            species='Homo sapiens'
+        )

--- a/siibra/features/tabular/bigbrain_intensity_profile.py
+++ b/siibra/features/tabular/bigbrain_intensity_profile.py
@@ -17,7 +17,7 @@ from . import cortical_profile
 
 from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
-    from ...locations import point
+    from ...features.anchor import AnatomicalAnchor
 
 
 class BigBrainIntensityProfile(
@@ -40,18 +40,11 @@ class BigBrainIntensityProfile(
 
     def __init__(
         self,
-        regionname: str,
+        anchor: "AnatomicalAnchor",
         depths: list,
         values: list,
-        boundaries: list,
-        location: 'point.Point'
+        boundaries: list
     ):
-        from ..anchor import AnatomicalAnchor
-        anchor = AnatomicalAnchor(
-            location=location,
-            region=regionname,
-            species='Homo sapiens'
-        )
         cortical_profile.CorticalProfile.__init__(
             self,
             description=self.DESCRIPTION,

--- a/siibra/features/tabular/layerwise_bigbrain_intensities.py
+++ b/siibra/features/tabular/layerwise_bigbrain_intensities.py
@@ -19,6 +19,10 @@ from . import tabular
 import pandas as pd
 import numpy as np
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ...features.anchor import AnatomicalAnchor
+
 
 class LayerwiseBigBrainIntensities(
     tabular.Tabular,
@@ -39,16 +43,10 @@ class LayerwiseBigBrainIntensities(
 
     def __init__(
         self,
-        regionname: str,
+        anchor: "AnatomicalAnchor",
         means: list,
         stds: list,
     ):
-
-        from ..anchor import AnatomicalAnchor
-        anchor = AnatomicalAnchor(
-            region=regionname,
-            species='Homo sapiens',
-        )
         data = pd.DataFrame(
             np.array([means, stds]).T,
             columns=['mean', 'std'],

--- a/siibra/livequeries/bigbrain.py
+++ b/siibra/livequeries/bigbrain.py
@@ -88,12 +88,16 @@ class BigBrainProfileQuery(query.LiveQuery, args=[], FeatureType=bigbrain_intens
         matched = concept.intersection(pointset.PointSet(loader._vertices, space='bigbrain'))
         assert matched.labels is not None
         for i in matched.labels:
+            anchor = _anchor.AnatomicalAnchor(
+                location=point.Point(loader._vertices[i], space='bigbrain'),
+                region=str(concept),
+                species='Homo sapiens'
+            )
             prof = bigbrain_intensity_profile.BigBrainIntensityProfile(
-                regionname=str(concept),
+                anchor=anchor,
                 depths=loader.profile_labels,
                 values=loader._profiles[i],
-                boundaries=loader._boundary_depths[i],
-                location=point.Point(loader._vertices[i], space='bigbrain')
+                boundaries=loader._boundary_depths[i]
             )
             prof.anchor._assignments[concept] = _anchor.AnatomicalAssignment(
                 query_structure=concept,
@@ -128,12 +132,16 @@ class LayerwiseBigBrainIntensityQuery(query.LiveQuery, args=[], FeatureType=laye
             for b in boundary_depths
         ]).reshape((-1, 200))
 
+        anchor = _anchor.AnatomicalAnchor(
+            location=pointset.PointSet(loader._vertices[indices, :], space='bigbrain'),
+            region=str(concept),
+            species='Homo sapiens'
+        )
         result = layerwise_bigbrain_intensities.LayerwiseBigBrainIntensities(
-            regionname=str(concept),
+            anchor=anchor,
             means=[matched_profiles[layer_labels == layer].mean() for layer in range(1, 7)],
             stds=[matched_profiles[layer_labels == layer].std() for layer in range(1, 7)],
         )
-        result.anchor._location_cached = pointset.PointSet(loader._vertices[indices, :], space='bigbrain')
         result.anchor._assignments[concept] = _anchor.AnatomicalAssignment(
             query_structure=concept,
             assigned_structure=concept,


### PR DESCRIPTION
This PR increases the speed of combining anchors of Bigbrain intensity profiles significantly since the pairwise summing of point anchors scales linearly with the number of points. Potentially, there could be 170k points if one queries for the whole big brain template. This could take up to an hour with the current methods. This PR allows the implementation of a method special to such features to quickly produce a merged anchor.

```python
import siibra
fts = siibra.features.get(siibra.get_template('bigbrain'), siibra.features.cellular.BigBrainIntensityProfile)
```

Or simply
```python
import siibra
fts = siibra.features.get(siibra.get_region('julich 2.9', 'occipital cortex'), siibra.features.cellular.BigBrainIntensityProfile)
```
speeds up from 136.9s to 0.03s (on an i5-1145G7)