### PR TITLE
Feat map to zip

### DIFF
--- a/e2e/volumes/test_tozip.py
+++ b/e2e/volumes/test_tozip.py
@@ -2,7 +2,7 @@ import pytest
 import siibra
 
 from siibra import MapType
-from siibra.volumes import Map
+from siibra.volumes import Map, Volume
 
 from zipfile import ZipFile
 import os
@@ -19,13 +19,16 @@ volumes_to_extract = [
 ]
 
 
-@pytest.mark.parametrize("siibramap", volumes_to_extract)
-def test_volume_to_zip(siibramap: Map):
-    zpname = f"{siibramap.name}.zip"
-    siibramap.to_zip(zpname)
+@pytest.mark.parametrize("volume", volumes_to_extract)
+def test_volume_to_zip(volume: Volume):
+    zpname = f"{volume.name}.zip"
+    volume.to_zip(zpname)
     with ZipFile(zpname) as zf:
         filenames = [info.filename for info in zf.filelist]
-        assert "README.md" in filenames
+        assert any(
+            fname.endswith("- README.md") and fname.startswith(volume.name)
+            for fname in filenames
+        ), filenames
     os.remove(zpname)
 
 
@@ -42,5 +45,9 @@ def test_map_to_zip(siibramap: Map):
     siibramap.to_zip(zpname)
     with ZipFile(zpname) as zf:
         filenames = [info.filename for info in zf.filelist]
-        assert "README.md" in filenames
+        for v in siibramap.volumes:
+            assert any(
+                fname.endswith("- README.md") and fname.startswith(v.name)
+                for fname in filenames
+            ), filenames
     os.remove(zpname)

--- a/e2e/volumes/test_tozip.py
+++ b/e2e/volumes/test_tozip.py
@@ -1,0 +1,46 @@
+import pytest
+import siibra
+
+from siibra import MapType
+from siibra.volumes import Map
+
+from zipfile import ZipFile
+import os
+
+
+volumes_to_extract = [
+    siibra.features.cellular.CellbodyStainedSection._get_instances()[0],
+    siibra.features.cellular.CellbodyStainedSection._get_instances()[5],
+    siibra.features.cellular.CellBodyStainedVolumeOfInterest._get_instances()[1],
+    siibra.features.macrostructural.BlockfaceVolumeOfInterest._get_instances()[0],
+    siibra.get_template('bigbrain'),
+    siibra.get_template('mni152'),
+    siibra.get_template('fsaverage6')
+]
+
+
+@pytest.mark.parametrize("siibramap", volumes_to_extract)
+def test_volume_to_zip(siibramap: Map):
+    zpname = f"{siibramap.name}.zip"
+    siibramap.to_zip(zpname)
+    with ZipFile(zpname) as zf:
+        filenames = [info.filename for info in zf.filelist]
+        assert "README.md" in filenames
+    os.remove(zpname)
+
+
+maps_to_extract = [
+    siibra.get_map("julich 3", "mni152"),
+    siibra.get_map("julich 2.9", "mni152"),  # contains fragments
+    siibra.get_map("difumo 64", "mni152", MapType.STATISTICAL),  # contains subvolumes
+]
+
+
+@pytest.mark.parametrize("siibramap", maps_to_extract)
+def test_map_to_zip(siibramap: Map):
+    zpname = f"{siibramap.name}.zip"
+    siibramap.to_zip(zpname)
+    with ZipFile(zpname) as zf:
+        filenames = [info.filename for info in zf.filelist]
+        assert "README.md" in filenames
+    os.remove(zpname)

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -56,6 +56,63 @@ with open(os.path.join(ROOT_DIR, "VERSION"), "r") as fp:
     __version__ = fp.read().strip()
 
 
+def create_readme(name: str, datasets: list, description: str = "") -> str:
+    ebrains_page = "\n".join(
+        {ds.ebrains_page for ds in datasets if getattr(ds, "ebrains_page", None)}
+    )
+    doi = "\n".join({
+        u.get("url")
+        for ds in datasets if ds.urls
+        for u in ds.urls
+    })
+    authors = ", ".join({
+        cont.get('name')
+        for ds in datasets if ds.contributors
+        for cont in ds.contributors
+    })
+    publication_desc = "\n".join({ds.description for ds in datasets})
+    if (ebrains_page or doi) and authors:
+        _README_PUBLICATIONS = """
+        Publications
+        ------------
+        {doi}
+
+        {ebrains_page}
+
+        {authors}
+
+        {publication_desc}
+
+        """
+        publications = _README_PUBLICATIONS.format(
+            ebrains_page="EBRAINS page\n" + ebrains_page if ebrains_page else "",
+            doi="DOI\n" + doi if doi else "",
+            authors="Authors\n" + authors if authors else "",
+            publication_desc="Publication description\n" + publication_desc if publication_desc else ""
+        )
+    else:
+        publications = "Note: could not obtain any publication information. The data may not have been published yet."
+
+    _README_TMPL = """
+    Downloaded from siibra toolsuite.
+    siibra-python version: {version}
+
+    All releated resources (e.g. doi, web resources) are categorized under publications.
+
+    Name
+    ----
+    {name}
+
+    {publications}
+    """
+    return _README_TMPL.format(
+        version=__version__,
+        name=name,
+        description=description,
+        publications=publications
+    )
+
+
 @dataclass
 class CompareMapsResult:
     intersection_over_union: float

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -56,6 +56,33 @@ with open(os.path.join(ROOT_DIR, "VERSION"), "r") as fp:
     __version__ = fp.read().strip()
 
 
+_README_PUBLICATIONS = """
+Publications
+------------
+{doi}
+
+{ebrains_page}
+
+{authors}
+
+{publication_desc}
+
+"""
+
+_README_TMPL = """
+    Downloaded from siibra toolsuite.
+    siibra-python version: {version}
+
+    All releated resources (e.g. doi, web resources) are categorized under publications.
+
+    Name
+    ----
+    {name}
+
+    {publications}
+    """
+
+
 def create_readme(name: str, datasets: list, description: str = "") -> str:
     ebrains_page = "\n".join(
         {ds.ebrains_page for ds in datasets if getattr(ds, "ebrains_page", None)}
@@ -72,18 +99,6 @@ def create_readme(name: str, datasets: list, description: str = "") -> str:
     })
     publication_desc = "\n".join({ds.description for ds in datasets})
     if (ebrains_page or doi) and authors:
-        _README_PUBLICATIONS = """
-        Publications
-        ------------
-        {doi}
-
-        {ebrains_page}
-
-        {authors}
-
-        {publication_desc}
-
-        """
         publications = _README_PUBLICATIONS.format(
             ebrains_page="EBRAINS page\n" + ebrains_page if ebrains_page else "",
             doi="DOI\n" + doi if doi else "",
@@ -93,18 +108,6 @@ def create_readme(name: str, datasets: list, description: str = "") -> str:
     else:
         publications = "Note: could not obtain any publication information. The data may not have been published yet."
 
-    _README_TMPL = """
-    Downloaded from siibra toolsuite.
-    siibra-python version: {version}
-
-    All releated resources (e.g. doi, web resources) are categorized under publications.
-
-    Name
-    ----
-    {name}
-
-    {publications}
-    """
     return _README_TMPL.format(
         version=__version__,
         name=name,

--- a/siibra/features/feature.py
+++ b/siibra/features/feature.py
@@ -233,16 +233,16 @@ class Feature:
                 break
         return prefix + md5(self.name.encode("utf-8")).hexdigest()
 
-    def _to_zip(self, fh: ZipFile):
+    def _to_zip(self, zf: ZipFile):
         """
         Internal implementation. Subclasses can override but call super()._to_zip(fh).
         This allows all classes in the __mro__ to have the opportunity to append files
         of interest.
         """
-        if isinstance(self, Compoundable) and "README.md" in fh.namelist():
+        if isinstance(self, Compoundable) and "README.md" in zf.namelist():
             return
 
-        fh.writestr(
+        zf.writestr(
             "README.md",
             create_readme(self.name, self.datasets, self.description)
         )

--- a/siibra/features/image/image.py
+++ b/siibra/features/image/image.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Base type of features in volume format and related anatomical anchor."""
 
-from zipfile import ZipFile
 from .. import feature
 
 from .. import anchor as _anchor
@@ -22,7 +21,8 @@ from .. import anchor as _anchor
 from ...volumes import volume as _volume
 from ...volumes.providers import provider
 
-from typing import List
+from typing import List, Union, BinaryIO
+from zipfile import ZipFile
 
 
 class ImageAnchor(_anchor.AnatomicalAnchor):
@@ -84,9 +84,19 @@ class Image(feature.Feature, _volume.Volume):
         self._description_cached = None
         self._name_cached = name
 
-    def _to_zip(self, fh: ZipFile, **fetch_kwargs):
-        super(feature.Feature, self)._to_zip(fh, **fetch_kwargs)  # volume
-        super(Image, self)._to_zip(fh)  # feature
+    def to_zip(self, filelike: Union[str, BinaryIO], **fetch_kwargs):
+        """
+        Export as a zip archive.
+
+        Parameters
+        ----------
+        filelike: str or path
+            Filelike to write the zip file. User is responsible to ensure the
+            correct extension (.zip) is set.
+        """
+        with ZipFile(filelike, "w") as zf:
+            super(Image, self)._to_zip(zf)  # feature
+            super(feature.Feature, self)._to_zip(zf, **fetch_kwargs)  # volume
 
     @property
     def name(self):

--- a/siibra/features/image/image.py
+++ b/siibra/features/image/image.py
@@ -84,12 +84,9 @@ class Image(feature.Feature, _volume.Volume):
         self._description_cached = None
         self._name_cached = name
 
-    def _to_zip(self, fh: ZipFile):
-        super()._to_zip(fh)
-        # How, what do we download?
-        # e.g. for marcel's volume, do we download at full resolution?
-        # cannot implement until Volume has an export friendly method
-        fh.writestr("volume.txt", "Volume cannot be downloaded yet.")
+    def _to_zip(self, fh: ZipFile, **fetch_kwargs):
+        super(feature.Feature, self)._to_zip(fh, **fetch_kwargs)  # volume
+        super(Image, self)._to_zip(fh)  # feature
 
     @property
     def name(self):

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -454,6 +454,10 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
             for i in range(len(self))
         )
 
+    def get_volume(self, region: str):
+        index = self.get_index(region)
+        return _volume.Subvolume(self.volumes[index.volume], index.label)
+
     @property
     def provides_image(self):
         return any(v.provides_image for v in self.volumes)

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -151,6 +151,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                 self._indices[k].append(
                     MapIndex(volume=remap_volumes[vol, z], label=index.get('label'), fragment=index.get('fragment'))
                 )
+        assert len(self.volumes) > 0, exceptions.NoVolumeFound("No volumes are associated with this map.")
 
         # make sure the indices are unique - each map/label pair should appear at most once
         all_indices = sum(self._indices.values(), [])
@@ -232,6 +233,11 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
         matches = matched_region_names & self._indices.keys()
         if len(matches) == 0:
             logger.warning(f"Region {regionname} not defined in {self}")
+        if isinstance(region, _region.Region) and region.parcellation != self.parcellation:
+            logger.info(
+                f"Parcellation of the supplied region {region} does not match "
+                f"maps ({self.parcellation}). Used the region name for matching."
+            )
         return {
             idx: regionname
             for regionname in matches
@@ -319,90 +325,147 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
     def regions(self):
         return list(self._indices)
 
-    def fetch(
+    def get_volume(
         self,
         region_or_index: Union[str, "Region", MapIndex] = None,
-        *,
-        index: MapIndex = None,
-        region: Union[str, "Region"] = None,
+        create_new_volume: bool = False,
         **kwargs
     ):
         """
-        Fetches one particular volume of this parcellation map.
+        Obtain the volume matching the specification.
 
-        If there's only one volume, this is the default, otherwise further
-        specification is requested:
-        - the volume index,
-        - the MapIndex (which results in a regional map being returned)
-
-        You might also consider fetch_iter() to iterate the volumes, or
-        compress() to produce a single-volume parcellation map.
+        Tip
+        ---
+        Use `fetch()` to obtain image or mesh
 
         Parameters
         ----------
         region_or_index: str, Region, MapIndex
-            Lazy match the specification.
-        index: MapIndex
-            Explicit specification of the map index, typically resulting
-            in a regional map (mask or statistical map) to be returned.
-            Note that supplying 'region' will result in retrieving the map index of that region
-            automatically.
-        region: str, Region
-            Specification of a region name, resulting in a regional map
-            (mask or statistical map) to be returned.
-        **kwargs
-            - resolution_mm: resolution in millimeters
-            - format: the format of the volume, like "mesh" or "nii"
-            - voi: a BoundingBox of interest
+            Lazy match the specification to fetch a regional map (mask or statistical map).
+            - Explicit specification of the MapIndex.
+            - Region name (str) or Region object.
+            If create_new_volume is False, returns the full volume associated
+            with the specifications.
 
+        create_new_volume: bool. Default: False
+            If True, it will create a new volume according to requested
+            specifications. Otherwise, the full volume containing the
+            specification is returned (for example, whole map instead of
+            regional map).
 
             Note
             ----
-            Not all keyword arguments are supported for volume formats. Format
-            is restricted by available formats (check formats property).
+            This requires fetching the data to create a volume out of the specifications. Therefore, it is slower.
+
+        **kwargs
+            - format: the format of the volume, like "nii" or optionally "mesh" or "image" (see `map.formats`)
+            - voi: a BoundingBox of interest
+            - fragment: Optional name of a fragment volume to fetch (see `map.fragments`)
+            - resolution_mm: resolution in millimeters
+            - max_bytes: maximum allowable size (in bytes) for downloading the image.
+
+            Note
+            ----
+            Not all keyword arguments are supported for volume formats.
 
         Returns
         -------
-        An image or mesh
+        Volume
         """
         try:
-            length = len([arg for arg in [region_or_index, region, index] if arg is not None])
-            assert length == 1
-        except AssertionError:
-            if length > 1:
-                raise exceptions.ExcessiveArgumentException("One and only one of region_or_index, region, index can be defined for fetch")
-            # user can provide no arguments, which assumes one and only one volume present
-
-        if isinstance(region_or_index, MapIndex):
-            index = region_or_index
-
-        if isinstance(region_or_index, (str, _region.Region)):
-            region = region_or_index
-
-        mapindex = None
-        if region is not None:
-            assert isinstance(region, (str, _region.Region))
-            mapindex = self.get_index(region)
-        if index is not None:
-            assert isinstance(index, MapIndex)
-            mapindex = index
-        if mapindex is None:
+            index, forward_kwargs = self._decode_fetch_index(
+                region_or_index=region_or_index, **kwargs
+            )
+        except exceptions.InsufficientArgumentException:
             if len(self) == 1:
-                mapindex = MapIndex(volume=0, label=None)
+                return self.volumes[0]
             elif len(self) > 1:
-                logger.info(
-                    "Map provides multiple volumes and no specification is"
-                    " provided. Resampling all volumes to the space."
+                if create_new_volume:
+                    logger.info(
+                        "Map provides multiple volumes and no specification is"
+                        " provided. Resampling all volumes to the space."
+                    )
+                    labels = list(range(len(self.volumes)))
+                    return _volume.merge(self.volumes, labels, **kwargs)
+                else:
+                    raise ValueError(
+                        "Map provides multiple volumes and no specification is "
+                        "provided. To allow resampling all volumes to its space"
+                        " and merge them, set `create_new_volume=True`."
+                    )
+
+        if create_new_volume:
+            from ..volumes import from_nifti
+            return from_nifti(
+                self.volumes[index.volume].fetch(
+                    fragment=index.fragment, label=index.label, **forward_kwargs
+                ),
+                space=self.space,
+                name=f"{self.name} - {index}"
+            )
+        return self.volumes[index.volume]
+
+    def _decode_fetch_index(
+        self,
+        region_or_index: Union[str, "Region", MapIndex] = None,
+        **kwargs
+    ) -> Tuple[MapIndex, Dict]:
+        """
+        Helper function to determine MapIndex required to fetch or get a volume.
+
+        Parameters
+        ----------
+        see `Map.fetch()`
+
+        Returns
+        -------
+        Tuple(MapIndex, Dict)
+            Found MapIndex and MapIndex kwargs taken out of kwargs.
+
+        Raises
+        ------
+        IndexError
+            If MapIndex provided but volume or label is not found in the map.
+        InsufficientArgumentException
+            There is nothing to decode.
+        ValueError
+            `region_or_index` is of the wrong type.
+        ConflictingArgumentException
+            If specified `region_or_index` and `fragement` does not match.
+        """
+        # determine map index
+        if region_or_index is None:
+            # to preserve legacy 'index', 'region', 'label' kwargs
+            if 'index' in kwargs:
+                mapindex = kwargs.pop('index')
+                assert isinstance(mapindex, MapIndex)
+                if (mapindex.volume is None or mapindex.volume >= len(self.volumes)):
+                    raise IndexError(
+                        f"{self} provides {len(self)} mapped volumes, but #{mapindex.volume} was requested."
+                    )
+                if mapindex.label not in self.labels:
+                    raise IndexError(f"{mapindex.label} is not in labels of {self}.")
+            elif 'region' in kwargs:
+                mapindex = self.get_index(kwargs.pop('region'))
+            elif "label" in kwargs:
+                return MapIndex(
+                    volume=kwargs.pop('volume', 0),
+                    label=kwargs.pop('label'),
+                    fragment=kwargs.pop('fragment', None)
                 )
-                labels = list(range(len(self.volumes)))
-                merged_volume = _volume.merge(self.volumes, labels, **kwargs)
-                return merged_volume.fetch()
             else:
-                raise exceptions.NoVolumeFound("Map provides no volumes.")
+                raise exceptions.InsufficientArgumentException
+        elif isinstance(region_or_index, MapIndex):
+            mapindex = region_or_index
+        elif isinstance(region_or_index, (str, _region.Region)):
+            mapindex = self.get_index(region_or_index)
+        else:
+            raise ValueError(
+                f"Invalid `region_or_index` of type {type(region_or_index)}. "
+                "Please supply a region name or MapIndex."
+            )
 
-        if "resolution_mm" in kwargs and kwargs.get("format") is None:
-            kwargs["format"] = 'neuroglancer/precomputed'
-
+        # Ensure fragment is not provided falsely
         kwargs_fragment = kwargs.pop("fragment", None)
         if kwargs_fragment is not None:
             if (mapindex.fragment is not None) and (kwargs_fragment != mapindex.fragment):
@@ -412,21 +475,60 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                 )
             mapindex.fragment = kwargs_fragment
 
-        if mapindex.volume is None:
-            mapindex.volume = 0
-        if mapindex.volume >= len(self.volumes):
-            raise IndexError(
-                f"{self} provides {len(self)} mapped volumes, but #{mapindex.volume} was requested."
-            )
+        return mapindex, kwargs
+
+    def fetch(
+        self,
+        region_or_index: Union[str, "Region", MapIndex] = None,
+        **kwargs
+    ):
+        """
+        Fetches one particular volume of this parcellation map, or a regional
+        map if `region_or_index` supplied. If a volume has fragments and one
+        is not speciified (with `fragment` kwarg), the fragments will be merged
+        into one image/mesh.
+
+        Tips
+        ----
+        - You can iterate over regional maps with `fetch_iter()`
+        - `Map.compress()` produces a single-volume parcellation map from
+        fragmented or multi-volume maps.
+
+        Parameters
+        ----------
+        region_or_index: str, Region, MapIndex
+            Lazy match the specification to fetch a regional map (mask or statistical map).
+            - Explicit specification of the MapIndex.
+            - Region name (str) or Region object.
+
+        **kwargs
+            - format: the format of the volume, like "nii" or optionally "mesh" or "image" (see `map.formats`)
+            - voi: a BoundingBox of interest
+            - fragment: Optional name of a fragment volume to fetch (see `map.fragments`)
+            - resolution_mm: resolution in millimeters
+            - max_bytes: maximum allowable size (in bytes) for downloading the image.
+
+            Note
+            ----
+            Not all keyword arguments are supported for volume formats.
+
+        Returns
+        -------
+        Nifti1Image or a mesh (Dict['verts': ndarray, 'faces': ndarray])
+        """
+        index, forward_kwargs = self._decode_fetch_index(region_or_index=region_or_index, **kwargs)
+        volume = self.get_volume(index, create_new_volume=True, **forward_kwargs)
+
         try:
-            result = self.volumes[mapindex.volume or 0].fetch(
-                fragment=mapindex.fragment, label=mapindex.label, **kwargs
-            )
-        except requests.SiibraHttpRequestError as e:
-            print(str(e))
+            result = volume.fetch(fragment=index.fragment, label=index.label, **forward_kwargs)
+        except requests.SiibraHttpRequestError:
+            logger.info(exc_info=1)
 
         if result is None:
-            raise RuntimeError(f"Error fetching {mapindex} from {self} as {kwargs.get('format', f'{self.formats}')}.")
+            raise RuntimeError(
+                f"Error fetching {index} from {self} as "
+                f"{kwargs.get('format', f'{self.formats}')}."
+            )
 
         return result
 

--- a/siibra/volumes/providers/neuroglancer.py
+++ b/siibra/volumes/providers/neuroglancer.py
@@ -44,6 +44,10 @@ class NeuroglancerProvider(_provider.VolumeProvider, srctype="neuroglancer/preco
             raise ValueError(f"Invalid url specified for {self.__class__.__name__}: {url}")
 
     @property
+    def fragments(self):
+        return [k for k in self._fragments if k is not None]
+
+    @property
     def _url(self) -> Union[str, Dict[str, str]]:
         return self._init_url
 
@@ -539,6 +543,10 @@ class NeuroglancerMesh(_provider.VolumeProvider, srctype="neuroglancer/precompme
             self._meshes = {n: self._fragmentinfo(u) for n, u in resource.items()}
         else:
             raise ValueError(f"Resource specificaton not understood for {self.__class__.__name__}: {resource}")
+
+    @property
+    def fragments(self):
+        return [k for k in self._meshes if k is not None]
 
     @property
     def _url(self) -> Union[str, Dict[str, str]]:

--- a/siibra/volumes/providers/provider.py
+++ b/siibra/volumes/providers/provider.py
@@ -97,7 +97,13 @@ class SubvolumeProvider(VolumeProvider, srctype="subvolume"):
             vol = self.__class__._FETCHED_VOLUMES[data_key]
         else:
             vol = self.provider.fetch(**kwargs)
-        return vol.slicer[:, :, :, self.z]
+        if len(vol.shape) == 4:
+            return vol.slicer[:, :, :, self.z]
+        else:
+            return Nifti1Image(
+                (vol.get_fdata() == self.z).astype('uint8'),
+                vol.affine
+            )
 
     def __getattr__(self, attr):
         return self.provider.__getattribute__(attr)


### PR DESCRIPTION
Save volumes and parcellation maps to a zip file. See e2e/volumes/test_tozip.py for example code.

Notes:
- Saves meshes as .gii
- Each volume of a map returns a readme.
- It was decided in [dev meeting on 2024.01.25](https://github.com/FZJ-INM1-BDA/siibra-development/blob/main/meetings/2024/20240125.md) that there should be a level before calling `fetch`, i.e., `get_volume` so that the over arching design pattern remains (`fetch` takes out user to inter-operable data types). However, this created a lot of overhead which is not expected when getting a volume object should not cause. It also made the code more complicated. (see https://github.com/FZJ-INM1-BDA/siibra-python/pull/554/commits/6867cff79fea8572ae6b37b7590c17515cc33616)

Unit test test/retrieval/test_retrieval_download_file.py is failing due to data-proxy being down.