### PR TITLE
Maint: `volume.fetch`

### DIFF
--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -364,7 +364,7 @@ class Volume(location.Location):
                 except Exception as e:
                     logger.info(e, exc_info=1)
                     break
-            # udpate the cache if fetch is succesful
+            # udpate the cache if fetch is successful
             if result is not None:
                 self._FETCH_CACHE[fetch_hash] = result
                 while len(self._FETCH_CACHE) >= self._FETCH_CACHE_MAX_ENTRIES:
@@ -372,7 +372,7 @@ class Volume(location.Location):
                     self._FETCH_CACHE.pop(next(iter(self._FETCH_CACHE)))
                 break
         else:
-            # unsuccesful: do not poison the cache if none fetched
+            # unsuccessful: do not poison the cache if none fetched
             logger.error(f"Could not fetch any formats from {possible_formats}.")
             return None
 

--- a/test/volumes/test_volume.py
+++ b/test/volumes/test_volume.py
@@ -43,7 +43,7 @@ class TestVolume(unittest.TestCase):
         self.assertIsNotNone(self.volume)
 
     def test_formats(self):
-        self.assertSetEqual(self.volume.formats, {'foo-bar', 'image'})
+        self.assertSetEqual(self.volume.formats, {'foo-bar'})
 
     @parameterized.expand([
         ({"@id": "foo"}, "foo", True, True),


### PR DESCRIPTION
During the last refactoring, this method has been changed a few times, leaving some artifacts and small issue to resolve. This PR addresses these.
- Clean up the code
- Repeat only in case of too many requests
- Check if "resolution_mm" supplied without format and set to NG (this behaviour already existent in `parcellationmap.Map.fetch()` but this is going to be removed as it is not it's job.) (Alternatively, the fetch can fail at, say `NiftiProvider.fetch()` but it is not user's job to know which formats are shipped with different resolutions. And since we decided against resampling nifti images if resolution_mm is supplied, this seems to be the best solution at the moment.)
- `formats` property should only list actual formats otherwise recursion occurs.