### PR TITLE
fix: write lock for warmup

### DIFF
--- a/siibra/retrieval/cache.py
+++ b/siibra/retrieval/cache.py
@@ -208,8 +208,8 @@ class Warmup:
                 return
             for f in return_val:
                 f()
-        
-        with Lock(f"{SIIBRA_CACHEDIR}/warmup.tmp"):
+
+        with Lock(CACHE.build_filename("lockfile", ".warmup")):
             with ThreadPoolExecutor(max_workers=max_workers) as ex:
                 for _ in siibra_tqdm(
                     ex.map(

--- a/siibra/retrieval/cache.py
+++ b/siibra/retrieval/cache.py
@@ -23,12 +23,7 @@ from enum import Enum
 from typing import Callable, List, NamedTuple, Union
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-import platform
-
-if platform.system() == "Linux":
-    from filelock import FileLock as Lock
-else:
-    from filelock import SoftFileLock as Lock
+from filelock import FileLock as Lock
 
 from ..commons import logger, SIIBRA_CACHEDIR, SKIP_CACHEINIT_MAINTENANCE, siibra_tqdm
 from ..exceptions import WarmupRegException

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -43,6 +43,8 @@ from functools import wraps
 from time import sleep
 import sys
 from filelock import FileLock as Lock
+if TYPE_CHECKING:
+    from .repositories import GitlabConnector
 
 USER_AGENT_HEADER = {"User-Agent": f"siibra-python/{__version__}"}
 

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -42,15 +42,7 @@ from enum import Enum
 from functools import wraps
 from time import sleep
 import sys
-import platform
-
-if platform.system() == "Linux":
-    from filelock import FileLock as Lock
-else:
-    from filelock import SoftFileLock as Lock
-
-if TYPE_CHECKING:
-    from .repositories import GitlabConnector
+from filelock import FileLock as Lock
 
 USER_AGENT_HEADER = {"User-Agent": f"siibra-python/{__version__}"}
 

--- a/test/retrieval/test_cache.py
+++ b/test/retrieval/test_cache.py
@@ -145,4 +145,4 @@ def test_write_lock():
     expected_baseline = sleep_time * 2
 
     time_perf = tend_s - tstart_s
-    assert time_perf > expected_baseline, f"Expect second call to block"
+    assert time_perf > expected_baseline, "Expect second call to block"

--- a/test/retrieval/test_cache.py
+++ b/test/retrieval/test_cache.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
+from multiprocessing import Pool
 
 from siibra.retrieval.cache import WarmupLevel, Warmup, WarmupRegException
 
@@ -126,3 +127,22 @@ def test_register_warmup_called_level_high(register_all):
 
     dummy_data1.assert_called_once()
     dummy_data2.assert_called_once()
+
+
+def test_write_lock():
+    import time
+
+    sleep_time = 1
+
+    @Warmup.register_warmup_fn(WarmupLevel.TEST)
+    def sleep_for_x():
+        time.sleep(sleep_time)
+
+    tstart_s = time.time()
+    with Pool(2) as p:
+        p.map(Warmup.warmup, (WarmupLevel.TEST, WarmupLevel.TEST))
+    tend_s = time.time()
+    expected_baseline = sleep_time * 2
+
+    time_perf = tend_s - tstart_s
+    assert time_perf > expected_baseline, f"Expect second call to block"


### PR DESCRIPTION
Since warmup writes files, it is potentially possible to have multiple process trying to warmup simultaneously. 

This PR prevents simultaneous write by using a FileLock (or SoftFileLock in windows). 