### PR TITLE
Exclude background from connected_components

### DIFF
--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -534,11 +534,12 @@ def connected_components(imgdata: np.ndarray):
     Provide an iterator over connected components in the array
     """
     from skimage import measure
-    components = measure.label(imgdata > 0)
+    components = measure.label(imgdata > 0, connectivity=2)
     component_labels = np.unique(components)
     return (
         (label, (components == label).astype('uint8'))
         for label in component_labels
+        if label > 0
     )
 
 

--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -534,7 +534,7 @@ def connected_components(imgdata: np.ndarray):
     Provide an iterator over connected components in the array
     """
     from skimage import measure
-    components = measure.label(imgdata > 0, connectivity=2)
+    components = measure.label(imgdata, connectivity=2, background=0)
     component_labels = np.unique(components)
     return (
         (label, (components == label).astype('uint8'))


### PR DESCRIPTION
The `commons.connected_components` always returned at least two components - the background and the actual foreground structure. Of course the background is not desired. This PR excludes it.

I am quite sure that earlier siibra versions did not include the background component.