### PR TITLE
Use `nilearn.resample_to_img` for mreging fragments

### DIFF
--- a/siibra/commons.py
+++ b/siibra/commons.py
@@ -519,8 +519,7 @@ def resample_array_to_array(
     """
     from nibabel import Nifti1Image
     from nilearn.image import resample_to_img
-    interp = "nearest" if issubclass(source_data.dtype.type, np.integer) \
-        else 'linear'
+    interp = "nearest" if issubclass(source_data.dtype.type, np.integer) else 'linear'
     resampled_img = resample_to_img(
         Nifti1Image(source_data, source_affine),
         Nifti1Image(target_data, target_affine),

--- a/siibra/volumes/providers/nifti.py
+++ b/siibra/volumes/providers/nifti.py
@@ -108,7 +108,11 @@ class NiftiProvider(_provider.VolumeProvider, srctype="nii"):
         return bbox
 
     def _merge_fragments(self) -> nib.Nifti1Image:
+        from nilearn.image import resample_to_img
+
         # TODO this only performs nearest neighbor interpolation, optimized for float types.
+        interp = lambda tp: "nearest" if issubclass(tp, np.integer) else 'linear'
+
         bbox = self.get_boundingbox(clip=False, background=0.0)
         num_conflicts = 0
         result = None
@@ -119,26 +123,18 @@ class NiftiProvider(_provider.VolumeProvider, srctype="nii"):
                 s0 = np.identity(4)
                 s0[:3, -1] = list(bbox.minpoint.transform(np.linalg.inv(img.affine)))
                 result_affine = np.dot(img.affine, s0)  # adjust global bounding box offset to get global affine
-                voxdims = np.asanyarray(
-                    np.ceil(
-                        bbox.transform(np.linalg.inv(result_affine)).shape
-                    ),
-                    dtype="int"
-                )
+                voxdims = np.asanyarray(np.ceil(
+                    bbox.transform(np.linalg.inv(result_affine)).shape
+                ), dtype="int")
                 result_arr = np.zeros(voxdims, dtype=img.dataobj.dtype)
                 result = nib.Nifti1Image(dataobj=result_arr, affine=result_affine)
 
-            arr = np.asanyarray(img.dataobj)
-            Xs, Ys, Zs = np.where(arr != 0)
-            Xt, Yt, Zt, _ = np.split(
-                (np.dot(
-                    np.linalg.inv(result_affine),
-                    np.dot(img.affine, np.c_[Xs, Ys, Zs, Zs * 0 + 1].T)
-                ) + .5).astype('int'),
-                4, axis=0
-            )
-            num_conflicts += np.count_nonzero(result_arr[Xt, Yt, Zt])
-            result_arr[Xt, Yt, Zt] = arr[Xs, Ys, Zs]
+            # resample to merge template and update it
+            resampled = resample_to_img(img, result, interpolation=interp(img.dataobj.dtype.type))
+            arr = np.asanyarray(resampled.dataobj)
+            nonzero_voxels = arr != 0
+            num_conflicts += np.count_nonzero(result_arr[nonzero_voxels])
+            result_arr[nonzero_voxels] = arr[nonzero_voxels]
 
         if num_conflicts > 0:
             num_voxels = np.count_nonzero(result_arr)


### PR DESCRIPTION
Based on the [conversation ](https://github.com/FZJ-INM1-BDA/siibra-python/pull/561/files#r1496115337) at #561 
Code to test:
```python
import siibra
from nilearn import plotting
res = 0.68
fmt = 'neuroglancer/precomputed'
bg_img = siibra.get_template('mni152').fetch(format=fmt, resolution_mm=res)
mp = siibra.get_map('2.9', 'mni152')
cmap = mp.get_colormap()
img = mp.fetch(format=fmt, resolution_mm=res)
plotting.view_img(img, bg_img=bg_img, symmetric_cmap=False, cmap=cmap).open_in_browser()
```