### PR TITLE
Read freesurfer .annot files as fsaverage mesh labels

### DIFF
--- a/e2e/volumes/test_parcellationmap.py
+++ b/e2e/volumes/test_parcellationmap.py
@@ -140,3 +140,12 @@ def test_fetching_mask(siibramap: Map):
                 f"{siibramap}, {fmt}. Mask for {region} should only contain 0 "
                 f"and 1 but found: {unq_vals}"
             )
+
+
+def test_freesrufer_annot_map_fetch():
+    mp = siibra.get_map(parcellation="visf", space="fsaverage")
+    mesh = mp.fetch(fragment='left', variant='pial')
+    assert np.array_equal(
+        np.unique(mesh['labels']),
+        np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
+    )

--- a/e2e/volumes/test_parcellationmap.py
+++ b/e2e/volumes/test_parcellationmap.py
@@ -143,9 +143,18 @@ def test_fetching_mask(siibramap: Map):
 
 
 def test_freesurfer_annot_map_fetch():
-    mp = siibra.get_map(parcellation="visf", space="fsaverage")
-    mesh = mp.fetch(fragment='left', variant='pial')
-    assert np.array_equal(
-        np.unique(mesh['labels']),
-        np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
-    )
+    annotmaps = [
+        mp for mp in siibra.maps
+        if any(
+            fmt in ["freesurfer-annot", "zip/freesurfer-annot"]
+            for fmt in mp.formats
+        )
+    ]
+    if len(annotmaps) == 0:
+        pytest.skip("No freesurfer-annot map in the configuration.")
+    for mp in annotmaps:
+        mesh = mp.fetch(fragment='left', variant='pial')
+        assert np.array_equal(
+            np.unique(mesh['labels']),
+            np.array(mp.labels)
+        )

--- a/e2e/volumes/test_parcellationmap.py
+++ b/e2e/volumes/test_parcellationmap.py
@@ -142,7 +142,7 @@ def test_fetching_mask(siibramap: Map):
             )
 
 
-def test_freesrufer_annot_map_fetch():
+def test_freesurfer_annot_map_fetch():
     mp = siibra.get_map(parcellation="visf", space="fsaverage")
     mesh = mp.fetch(fragment='left', variant='pial')
     assert np.array_equal(

--- a/siibra/configuration/configuration.py
+++ b/siibra/configuration/configuration.py
@@ -42,7 +42,7 @@ class Configuration:
         conn(
             server_or_owner,
             project_or_repo,
-            reftag="add_visfAtlas",
+            reftag="siibra-{}".format(__version__),
             skip_branchtest=True
         )
         for conn, server_or_owner, project_or_repo in CONFIG_REPOS

--- a/siibra/configuration/configuration.py
+++ b/siibra/configuration/configuration.py
@@ -42,7 +42,7 @@ class Configuration:
         conn(
             server_or_owner,
             project_or_repo,
-            reftag="siibra-{}".format(__version__),
+            reftag="add_visfAtlas",
             skip_branchtest=True
         )
         for conn, server_or_owner, project_or_repo in CONFIG_REPOS

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -48,6 +48,20 @@ if TYPE_CHECKING:
 
 USER_AGENT_HEADER = {"User-Agent": f"siibra-python/{__version__}"}
 
+
+def read_annot_bytesio(bytesio: BytesIO):
+    """
+    Helper function to read .annot files with `nibabel.freesurfer.read_annot()`
+    since it only takes file path and cannot handle BytesIO.
+    """
+    tempannot = CACHE.build_filename("tempannot") + '.annot'
+    with open(tempannot, "wb") as bf:
+        bf.write(bytesio.getbuffer())
+    result = freesurfer.read_annot(tempannot)
+    os.remove(tempannot)
+    return result
+
+
 DECODERS = {
     ".nii": lambda b: Nifti1Image.from_bytes(b),
     ".gii": lambda b: GiftiImage.from_bytes(b),
@@ -59,7 +73,7 @@ DECODERS = {
     ".zip": lambda b: ZipFile(BytesIO(b)),
     ".png": lambda b: skimage_io.imread(BytesIO(b)),
     ".npy": lambda b: np.load(BytesIO(b)),
-    ".annot": lambda b: freesurfer.read_annot(BytesIO(b)),
+    ".annot": lambda b: read_annot_bytesio(BytesIO(b)),
 }
 
 

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -30,7 +30,7 @@ import json
 from zipfile import ZipFile
 import requests
 import os
-from nibabel import Nifti1Image, GiftiImage, streamlines
+from nibabel import Nifti1Image, GiftiImage, streamlines, freesurfer
 from skimage import io as skimage_io
 import gzip
 from io import BytesIO
@@ -59,6 +59,7 @@ DECODERS = {
     ".zip": lambda b: ZipFile(BytesIO(b)),
     ".png": lambda b: skimage_io.imread(BytesIO(b)),
     ".npy": lambda b: np.load(BytesIO(b)),
+    ".annot": lambda b: freesurfer.read_annot(BytesIO(b)),
 }
 
 

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 USER_AGENT_HEADER = {"User-Agent": f"siibra-python/{__version__}"}
 
 
-def readas_bytesio(function: Callable, suffix: str, bytesio: BytesIO):
+def read_as_bytesio(function: Callable, suffix: str, bytesio: BytesIO):
     """
     Helper method to provide BytesIO to methods that only takes file path and
     cannot handle BytesIO normally (e.g., `nibabel.freesurfer.read_annot()`).
@@ -68,11 +68,11 @@ def readas_bytesio(function: Callable, suffix: str, bytesio: BytesIO):
     -------
     Return type of the provided function.
     """
-    tempannot = CACHE.build_filename("tempannot") + suffix
-    with open(tempannot, "wb") as bf:
+    tempfile = CACHE.build_filename(f"temp_{suffix}") + suffix
+    with open(tempfile, "wb") as bf:
         bf.write(bytesio.getbuffer())
-    result = function(tempannot)
-    os.remove(tempannot)
+    result = function(tempfile)
+    os.remove(tempfile)
     return result
 
 
@@ -87,7 +87,7 @@ DECODERS = {
     ".zip": lambda b: ZipFile(BytesIO(b)),
     ".png": lambda b: skimage_io.imread(BytesIO(b)),
     ".npy": lambda b: np.load(BytesIO(b)),
-    ".annot": lambda b: readas_bytesio(freesurfer.read_annot, '.annot', BytesIO(b)),
+    ".annot": lambda b: read_as_bytesio(freesurfer.read_annot, '.annot', BytesIO(b)),
 }
 
 

--- a/siibra/volumes/providers/__init__.py
+++ b/siibra/volumes/providers/__init__.py
@@ -17,4 +17,4 @@
 from .neuroglancer import NeuroglancerProvider, NeuroglancerMesh
 from .nifti import NiftiProvider
 from .gifti import GiftiSurfaceLabeling, GiftiMesh
-from .freesurfer import ZippedFreesurferAnnot
+from .freesurfer import ZippedFreesurferAnnot, FreesurferAnnot

--- a/siibra/volumes/providers/__init__.py
+++ b/siibra/volumes/providers/__init__.py
@@ -17,3 +17,4 @@
 from .neuroglancer import NeuroglancerProvider, NeuroglancerMesh
 from .nifti import NiftiProvider
 from .gifti import GiftiSurfaceLabeling, GiftiMesh
+from .freesurfer import ZippedFreesurferAnnot

--- a/siibra/volumes/providers/freesurfer.py
+++ b/siibra/volumes/providers/freesurfer.py
@@ -16,7 +16,7 @@
 
 from . import provider as _provider
 
-from ...retrieval import requests
+from ...retrieval.requests import HttpRequest, ZipfileRequest
 
 import numpy as np
 from typing import Union, Dict, TYPE_CHECKING
@@ -25,13 +25,57 @@ if TYPE_CHECKING:
     from ...locations import boundingbox as _boundingbox
 
 
+class FreesurferAnnot(_provider.VolumeProvider, srctype="freesurfer-annot"):
+    def __init__(self, url: Union[str, dict]):
+        self._init_url = url
+        if isinstance(url, str):  # single mesh labelling
+            self._loaders = {None: HttpRequest(url)}
+        elif isinstance(url, dict):   # named label fragments
+            self._loaders = {lbl: HttpRequest(u) for lbl, u in url.items()}
+        else:
+            raise NotImplementedError(f"Urls for {self.__class__.__name__} are expected to be of type str.")
+
+    def fetch(self, fragment: str = None, label: int = None, **kwargs):
+        """Returns a 1D numpy array of label indices."""
+        vertex_labels = []
+        if fragment is None:
+            matched_frags = list(self._loaders.keys())
+        else:
+            matched_frags = [frg for frg in self._loaders.keys() if fragment.lower() in frg.lower()]
+            if len(matched_frags) != 1:
+                raise ValueError(
+                    f"Requested fragment '{fragment}' could not be matched uniquely "
+                    f"to [{', '.join(self._loaders)}]"
+                )
+        for frag in matched_frags:
+            frag_labels, *_ = self._loaders[frag].data
+            if label is not None:  # create the mask
+                selected_label = frag_labels == label
+                frag_labels[selected_label] = 1
+                frag_labels[~selected_label] = 0
+            else:
+                frag_labels[frag_labels == -1] = 0  # annot files store backgorund as -1 while siibra uses 0
+            vertex_labels.append(frag_labels)
+
+        return {"labels": np.hstack(vertex_labels)}
+
+    def get_boundingbox(self, clip=False, background=0.0) -> '_boundingbox.BoundingBox':
+        raise NotImplementedError(
+            f"Bounding box access to {self.__class__.__name__} objects not yet implemented."
+        )
+
+    @property
+    def _url(self) -> Union[str, Dict[str, str]]:
+        return self._init_url
+
+
 class ZippedFreesurferAnnot(_provider.VolumeProvider, srctype="zip/freesurfer-annot"):
     def __init__(self, url: Union[str, dict]):
         self._init_url = url
         if isinstance(url, str):  # single mesh labelling
-            self._loaders = {None: requests.ZipfileRequest(*url.split(" "))}
+            self._loaders = {None: ZipfileRequest(*url.split(" "))}
         elif isinstance(url, dict):   # named label fragments
-            self._loaders = {lbl: requests.ZipfileRequest(*u.split(" ")) for lbl, u in url.items()}
+            self._loaders = {lbl: ZipfileRequest(*u.split(" ")) for lbl, u in url.items()}
         else:
             raise NotImplementedError(f"Urls for {self.__class__.__name__} are expected to be of type str.")
 

--- a/siibra/volumes/providers/freesurfer.py
+++ b/siibra/volumes/providers/freesurfer.py
@@ -1,0 +1,69 @@
+# Copyright 2018-2021
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handles reading and preparing gii files."""
+
+from . import provider as _provider
+
+from ...retrieval import requests
+
+import numpy as np
+from typing import Union, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...locations import boundingbox as _boundingbox
+
+
+class ZippedFreesurferAnnot(_provider.VolumeProvider, srctype="zip/freesurfer-annot"):
+    def __init__(self, url: Union[str, dict]):
+        self._init_url = url
+        if isinstance(url, str):  # single mesh labelling
+            self._loaders = {None: requests.ZipfileRequest(*url.split(" "))}
+        elif isinstance(url, dict):   # named label fragments
+            self._loaders = {lbl: requests.ZipfileRequest(*u.split(" ")) for lbl, u in url.items()}
+        else:
+            raise NotImplementedError(f"Urls for {self.__class__.__name__} are expected to be of type str.")
+
+    def fetch(self, fragment: str = None, label: int = None, **kwargs):
+        """Returns a 1D numpy array of label indices."""
+        vertex_labels = []
+        if fragment is None:
+            matched_frags = list(self._loaders.keys())
+        else:
+            matched_frags = [frg for frg in self._loaders.keys() if fragment.lower() in frg.lower()]
+            if len(matched_frags) != 1:
+                raise ValueError(
+                    f"Requested fragment '{fragment}' could not be matched uniquely "
+                    f"to [{', '.join(self._loaders)}]"
+                )
+        for frag in matched_frags:
+            frag_labels, *_ = self._loaders[frag].data
+            if label is not None:  # create the mask
+                selected_label = frag_labels == label
+                frag_labels[selected_label] = 1
+                frag_labels[~selected_label] = 0
+            else:
+                frag_labels[frag_labels == -1] = 0  # annot files store backgorund as -1 while siibra uses 0
+            vertex_labels.append(frag_labels)
+
+        return {"labels": np.hstack(vertex_labels)}
+
+    def get_boundingbox(self, clip=False, background=0.0) -> '_boundingbox.BoundingBox':
+        raise NotImplementedError(
+            f"Bounding box access to {self.__class__.__name__} objects not yet implemented."
+        )
+
+    @property
+    def _url(self) -> Union[str, Dict[str, str]]:
+        return self._init_url

--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -52,7 +52,8 @@ class Volume(location.Location):
         "neuroglancer/precompmesh",
         "neuroglancer/precompmesh/surface",
         "gii-mesh",
-        "gii-label"
+        "gii-label",
+        "zip/freesurfer-annot"
     ]
 
     SUPPORTED_FORMATS = IMAGE_FORMATS + MESH_FORMATS
@@ -425,7 +426,7 @@ class Volume(location.Location):
             fwd_args = {k: v for k, v in kwargs.items() if k != "format"}
             for try_count in range(6):
                 try:
-                    if fmt == "gii-label":
+                    if fmt in ["gii-label", "zip/freesurfer-annot"]:
                         tpl = self.space.get_template(variant=kwargs.get('variant'))
                         mesh = tpl.fetch(**kwargs)
                         labels = self._providers[fmt].fetch(**fwd_args)

--- a/siibra/volumes/volume.py
+++ b/siibra/volumes/volume.py
@@ -53,7 +53,8 @@ class Volume(location.Location):
         "neuroglancer/precompmesh/surface",
         "gii-mesh",
         "gii-label",
-        "zip/freesurfer-annot"
+        "freesurfer-annot",
+        "zip/freesurfer-annot",
     ]
 
     SUPPORTED_FORMATS = IMAGE_FORMATS + MESH_FORMATS
@@ -426,7 +427,7 @@ class Volume(location.Location):
             fwd_args = {k: v for k, v in kwargs.items() if k != "format"}
             for try_count in range(6):
                 try:
-                    if fmt in ["gii-label", "zip/freesurfer-annot"]:
+                    if fmt in ["gii-label", "freesurfer-annot", "zip/freesurfer-annot"]:
                         tpl = self.space.get_template(variant=kwargs.get('variant'))
                         mesh = tpl.fetch(**kwargs)
                         labels = self._providers[fmt].fetch(**fwd_args)


### PR DESCRIPTION
```python
import siibra
from nilearn import plotting
conn = siibra.retrieval.repositories.GithubConnector("FZJ-INM1-BDA", "siibra-configurations", "add_visfAtlas")
siibra.use_configuration(conn)
mp = siibra.get_map(parcellation="visf", space="fsaverage")
mesh = mp.fetch(variant='inflated')
plotting.view_surf([mesh['verts'], mesh['faces']], surf_map=mesh['labels'], cmap=mp.get_colormap(), symmetric_cmap=False).open_in_browser()
```

See https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles for details of the freesurfer .annot files and https://nipy.org/nibabel/reference/nibabel.freesurfer.html#read-annot for implementation detail.