### PR TITLE
fix: pointset intersection with boundingbox fails if no points inside

### DIFF
--- a/siibra/locations/boundingbox.py
+++ b/siibra/locations/boundingbox.py
@@ -140,10 +140,11 @@ class BoundingBox(location.Location):
             warped = other.warp(self.space)
             return other if self.minpoint <= warped <= self.maxpoint else None
         if isinstance(other, pointset.PointSet):
+            points_inside = [p for p in other if self.intersects(p)]
             result = pointset.PointSet(
-                [p for p in other if self.intersects(p)],
+                points_inside,
                 space=other.space,
-                sigma_mm=other.sigma
+                sigma_mm=[p.sigma_mm for p in points_inside]
             )
             if len(result) == 0:
                 return None

--- a/siibra/locations/pointset.py
+++ b/siibra/locations/pointset.py
@@ -76,7 +76,10 @@ class PointSet(location.Location):
         if not isinstance(other, (point.Point, PointSet, _boundingbox.BoundingBox)):
             return other.intersection(self)
 
-        ids, points = zip(*[(i, p) for i, p in enumerate(self) if p.intersects(other)])
+        intersections = [(i, p) for i, p in enumerate(self) if p.intersects(other)]
+        if len(intersections) == 0:
+            return None
+        ids, points = zip(*intersections)
         labels = None if self.labels is None else [self.labels[i] for i in ids]
         sigma = [p.sigma for p in points]
         intersection = PointSet(
@@ -85,8 +88,6 @@ class PointSet(location.Location):
             sigma_mm=sigma,
             labels=labels
         )
-        if len(intersection) == 0:
-            return None
         return intersection[0] if len(intersection) == 1 else intersection
 
     @property


### PR DESCRIPTION
The pointset - boundingbox on main raised an exception if no points were inside the bonding box.

This PR should fix the problem.