### PR TITLE
Use precalculated image feature boundingboxes to speed up image feature query

### DIFF
--- a/siibra/configuration/configuration.py
+++ b/siibra/configuration/configuration.py
@@ -42,7 +42,7 @@ class Configuration:
         conn(
             server_or_owner,
             project_or_repo,
-            reftag="siibra-{}".format(__version__),
+            reftag="enh_use_precalc_img_bboxes",
             skip_branchtest=True
         )
         for conn, server_or_owner, project_or_repo in CONFIG_REPOS

--- a/siibra/configuration/factory.py
+++ b/siibra/configuration/factory.py
@@ -24,7 +24,7 @@ from ..features.tabular import (
 )
 from ..features.image import sections, volume_of_interest
 from ..core import atlas, parcellation, space, region
-from ..locations import point, pointset
+from ..locations import point, pointset, boundingbox
 from ..retrieval import datasets, repositories
 from ..volumes import volume, sparsemap, parcellationmap
 from ..volumes.providers import provider, gifti, neuroglancer, nifti
@@ -359,6 +359,16 @@ class Factory:
         return pointset.PointSet(coords, space=space_id)
 
     @classmethod
+    @build_type("siibra/location/boundingbox/v0.1")
+    def build_boundingbox(cls, spec):
+        bboxspec = spec.get("boundingbox", None)
+        if bboxspec is None:
+            return None
+        space_id = spec.get("space").get("@id")
+        coords = [tuple(c) for c in bboxspec.get("coordinates")]
+        return boundingbox.BoundingBox(coords[0], coords[1], space=space_id)
+
+    @classmethod
     @build_type("siibra/feature/fingerprint/receptor/v0.1")
     def build_receptor_density_fingerprint(cls, spec):
         return receptor_density_fingerprint.ReceptorDensityFingerprint(
@@ -408,6 +418,7 @@ class Factory:
             "space_spec": vol._space_spec,
             "providers": vol._providers.values(),
             "datasets": cls.extract_datasets(spec),
+            "boundingbox": cls.build_boundingbox(spec)
         }
         modality = spec.get('modality', "")
         if modality == "cell body staining":

--- a/siibra/features/image/image.py
+++ b/siibra/features/image/image.py
@@ -21,6 +21,7 @@ from .. import anchor as _anchor
 
 from ...volumes import volume as _volume
 from ...volumes.providers import provider
+from ...locations import boundingbox
 
 from typing import List
 
@@ -63,6 +64,7 @@ class Image(feature.Feature, _volume.Volume):
         providers: List[provider.VolumeProvider],
         region: str = None,
         datasets: List = [],
+        boundingbox: "boundingbox.BoundingBox" = None
     ):
         feature.Feature.__init__(
             self,
@@ -83,6 +85,15 @@ class Image(feature.Feature, _volume.Volume):
         self._anchor_cached = ImageAnchor(self, region=region)
         self._description_cached = None
         self._name_cached = name
+        self._boundingbox = boundingbox
+
+    def get_boundingbox(
+        self, clip: bool = True, background: float = 0.0, **fetch_kwargs
+    ) -> "boundingbox.BoundingBox":
+        if self._boundingbox is None:
+            return super().get_boundingbox(clip, background, **fetch_kwargs)
+        else:
+            return self._boundingbox
 
     def _to_zip(self, fh: ZipFile):
         super()._to_zip(fh)


### PR DESCRIPTION
The profiling revealed that most time is spend fetching the boundingboxes of images. When this information is cached, the query itself takes less than a second (on 11th Gen Intel(R) Core(TM) i5-1145G7, 16 GB memory). Therefore, this PR allows the bounding box information to be precalculated and stored in the configs to be used in run time. I suggest that we utilize this method for all image features until the new spatial query system is settled.