### PR TITLE
fix: python closure is weird

### DIFF
--- a/siibra/features/__init__.py
+++ b/siibra/features/__init__.py
@@ -53,7 +53,7 @@ def __getattr__(attr: str):
 
 
 @cache.Warmup.register_warmup_fn()
-def _warm_feature_cache_insntaces():
+def _warm_feature_cache_instances():
     """Preload preconfigured multimodal data features."""
     for ftype in TYPES.values():
         _ = ftype._get_instances()

--- a/siibra/features/__init__.py
+++ b/siibra/features/__init__.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Multimodal data features types and query mechanisms."""
 
+from typing import Union
+from functools import partial
+
 from . import (
     connectivity,
     tabular,
@@ -21,7 +24,8 @@ from . import (
     dataset,
 )
 
-from typing import Union
+from ..commons import logger
+
 from .feature import Feature
 from ..retrieval import cache
 from ..commons import siibra_tqdm
@@ -62,16 +66,17 @@ def _warm_feature_cache_data():
         instances = ftype._get_instances()
         tally = siibra_tqdm(desc=f"Warming data {ftype.__name__}", total=len(instances))
         for f in instances:
-            def get_data():
+            def get_data(feat: Feature):
                 # TODO
                 # the try catch is as a result of https://github.com/FZJ-INM1-BDA/siibra-python/issues/509
                 # sometimes f.data can fail
                 try:
-                    _ = f.data
-                except Exception:
-                    ...
-                tally.update(1)
-            return_callables.append(get_data)
+                    _ = feat.data
+                except Exception as e:
+                    logger.warn(f"Feature {feat.name} warmup failed: {str(e)}")
+                finally:
+                    tally.update(1)
+            return_callables.append(partial(get_data, f))
     return return_callables
 
 


### PR DESCRIPTION
fix closure bug

see a simplified reproduction:

```python

from concurrent.futures import ThreadPoolExecutor
from functools import partial

def call_fn(fn):
    fn()

def main():
    arr = []
    for i in range(10):
        def fn(j):
            print(j)
        arr.append(
            partial(fn, i)
        )
    
    with ThreadPoolExecutor(4) as ex:
        list(ex.map(
            call_fn,
            arr
        ))

def faulty():
    
    arr = []
    for i in range(10):
        def fn():
            print(i)
        arr.append(fn)
    
    with ThreadPoolExecutor(4) as ex:
        list(ex.map(
            call_fn,
            arr
        ))
    

if __name__ == "__main__":
    print("faulty")
    faulty()
    print("main")
    main()

```

prints

```
faulty
9
9
9
9
9
9
9
9
9
9
main
0
1
3
4
5
2
9
7
8
6
```