### PR TITLE
test: fast ci if regular branch, full suite if PR to main

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -1,0 +1,33 @@
+name: e2e Test
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+          
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -U .
+        pip install -r requirements-test.txt
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install test dependencies
+      run:  pip install pytest pytest-cov coverage
+    - name: Run test with pytest
+      shell: bash
+      run: pytest -rx e2e

--- a/.github/workflows/_importable.yaml
+++ b/.github/workflows/_importable.yaml
@@ -1,0 +1,28 @@
+name: Check Importable
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+
+jobs:
+  check-importable:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -U .
+    
+    - name: cd to / and try to import
+      run: |
+        cd / && python -c 'import siibra'

--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -1,0 +1,22 @@
+name: Lint
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+
+jobs:
+  lint:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '${{ inputs.python-version }}'
+    - run: pip install flake8
+    - run: flake8 .

--- a/.github/workflows/_unittest.yaml
+++ b/.github/workflows/_unittest.yaml
@@ -1,0 +1,30 @@
+name: Unit Test
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+
+jobs:
+  unit-tests:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '${{ inputs.python-version }}'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -U .
+        pip install -r requirements-test.txt
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install test dependencies
+      run:  pip install pytest pytest-cov coverage
+    - name: Run test with pytest
+      run: pytest -rx

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,6 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Generate coverage
       run: |
-        export FAST_RUN=1
         pytest --cov=siibra --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/cron-siibra-tutorials.yml
+++ b/.github/workflows/cron-siibra-tutorials.yml
@@ -8,7 +8,7 @@ jobs:
   test_tutorials:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/dockerimg.yml
+++ b/.github/workflows/dockerimg.yml
@@ -14,7 +14,7 @@ jobs:
         docker-repo: [ 'docker-registry.ebrains.eu' ]
         docker-file: [ 'Dockerfile' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: 'Set env var'
       run: |
         

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: '[Docs and examples] Create docs and run examples'
-on: [push, release]
+on: 
+  pull_request:
+    branches: [ 'main' ]
+  release:
+    types: [ 'published' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -10,7 +14,7 @@ jobs:
     name: "Build and run the notebooks for the docs"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/pyblish-release-to-pypi.yml
+++ b/.github/workflows/pyblish-release-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
       KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
       
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/siibra-testing.yml
+++ b/.github/workflows/siibra-testing.yml
@@ -1,126 +1,67 @@
 name: '[test] unit test'
 
-on: [push]
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ 'main' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+
   lint:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - run: pip install flake8
-    - run: flake8 .
-  unit-tests:
-    runs-on: ubuntu-latest
-    env:
-      # unit tests should not need tokens
-      
-      # KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
-      # KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
-      SIIBRA_LOG_LEVEL: DEBUG
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ '3.12', '3.11', '3.10', '3.9', '3.8', '3.7' ]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -U .
-        pip install -r requirements-test.txt
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Install test dependencies
-      run:  pip install pytest pytest-cov coverage
-    - name: Run test with pytest
-      run: |
-        echo "Using github.ref: $GITHUB_REF"
-        if [[ "$GITHUB_REF" != "refs/heads/main" ]]
-        then
-          export FAST_RUN=1
-        fi
-        pytest -rx
-  
-  e2e-tests:
-    runs-on: ${{ matrix.os }}
-    env:
-      # KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
-      # KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
-      FOO: BAR
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
-        python-version: [ '3.12', '3.11', '3.10', '3.9', '3.8', '3.7' ]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Cache SIIBRA_CACHEDIR
-      uses: actions/cache@v3
-      with:
-        path: ${{ runner.temp }}
-        key: ${{ runner.os }}
-        restore-keys: |
-          ${{ runner.os }}
-          
-    - name: Install dependencies
-      shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -U .
-        pip install -r requirements-test.txt
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Install test dependencies
-      run:  pip install pytest pytest-cov coverage
-    - name: Run test with pytest
-      shell: bash
-      run: |
-        export SIIBRA_CACHEDIR=${{ runner.temp }}
-        echo "Using github.ref: $GITHUB_REF"
-        if [[ "$GITHUB_REF" != "refs/heads/main" ]]
-        then
-          export FAST_RUN=1
-        fi
-        pytest -rx e2e
+    uses: ./.github/workflows/_lint.yml
+    with:
+      os: ubuntu-latest
+      python-version: '3.8'
 
   check-importable:
-    runs-on: ubuntu-latest
-    env:
-      KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
-      KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
+    uses: ./.github/workflows/_importable.yml
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [ '3.12', '3.11', '3.10', '3.9', '3.8', '3.7' ]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -U .
-    
-    - name: cd to / and try to import
-      run: |
-        cd / && python -c 'import siibra'
+
+  unit-tests-full:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/_unittest.yml
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.12', '3.11', '3.10', '3.9', '3.8', '3.7' ]
+  
+  unit-tests-fast:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/_unittest.yml
+    with:
+      os: ubuntu-latest
+      python-version: '3.8'
+
+
+  e2e-tests-full:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/_e2e.yml
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.12', '3.11', '3.10', '3.9', '3.8', '3.7' ]
+  
+  e2e-tests-fast:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/_e2e.yml
+    with:
+      os: ubuntu-latest
+      python-version: '3.8'
+


### PR DESCRIPTION
As of now, push to any branch will cause full suite of test to run. This takes a long time, and potentially becomes the bottleneck when new builds are pushed often. 

This PR changes this behavior:

- push to regular branch will run the baseline unit/e2e tests (ubuntu-latest/py3.8)
- any PR to main will trigger trigger full suite of tests (ubuntu/windows + py3.7-3.12)