### PR TITLE
Fix: get_region(spec) exact match if spec is a region key

### DIFF
--- a/siibra/core/parcellation.py
+++ b/siibra/core/parcellation.py
@@ -309,7 +309,11 @@ class Parcellation(region.Region, configuration_folder="parcellations"):
 
         # if there exist an exact match of region spec to region name, return
         if isinstance(regionspec, str):
-            exact_match = [region for region in self if hasattr(region, "name") and region.name == regionspec]
+            exact_match = [
+                region
+                for region in self
+                if region.name == regionspec or region.key == regionspec
+            ]
             if len(exact_match) == 1:
                 return exact_match[0]
             if len(exact_match) > 1:


### PR DESCRIPTION
```ipython
import siibra
p = siibra.parcellations['julich 3.1']
p.get_region('LP (Thalamus, lateral posterior Nucleus) right')
```
expected:
```python
<Region(identifier='minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-310_LP_THALAMUS_LATERAL_POSTERIOR_NUCLEUS_RIGHT', name='LP (Thalamus, lateral posterior Nucleus) right', species='Homo sapiens')>
```
but it was raising RuntimeError. This PR fixes this issue.