### PR TITLE
fix bbox planar intersection

### DIFF
--- a/e2e/features/image/test_image.py
+++ b/e2e/features/image/test_image.py
@@ -3,38 +3,48 @@ import pytest
 from siibra.features.image.image import Image
 import time
 
-# Update this as new configs are added
-results = [
-    (siibra.features.get(siibra.get_template("big brain"), "CellbodyStainedSection"), 145),
-    (siibra.features.get(siibra.get_template("big brain"), "CellBodyStainedVolumeOfInterest"), 2),
-    (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=True), 4),
-    (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=False), 13),
-    (siibra.features.get(siibra.get_region('julich 3.1', 'hoc1 left'), "CellbodyStainedSection"), 45),
-    (siibra.features.get(siibra.get_region('julich 2.9', 'hoc1 left'), "CellbodyStainedSection"), 41)
+PRERELEASE_FEATURES_W_NO_DATASET = [
+    "The Enriched Connectome - Block face images of full sagittal human brain sections (blockface)",
+    "The Enriched Connectome - 3D polarized light imaging connectivity data of full sagittal human brain sections (HSV fibre orientation map)",
 ]
-features = [f for fts, _ in results for f in fts]
+all_image_features = [f for ft in siibra.features.Feature._SUBCLASSES[siibra.features.image.image.Image] for f in ft._get_instances()]
 
 
-@pytest.mark.parametrize("feature", features)
+@pytest.mark.parametrize("feature", all_image_features)
 def test_feature_has_datasets(feature: Image):
-    assert len(feature.datasets) > 0
-
-
-@pytest.mark.parametrize("features, result_len", results)
-def test_image_query_results(
-    features: Image,
-    result_len: int
-):
-    assert len(features) == result_len
+    if feature.name in PRERELEASE_FEATURES_W_NO_DATASET:
+        if len(feature.datasets) > 0:
+            pytest.fail(f"Feature '{feature}' was listed as prerelase previosly but now have dataset information. Please update `PRERELEASE_FEATURES_W_NO_DATASET`")
+        pytest.skip(f"Feature '{feature}' has no datasets yet as it is a prerelease data.")
+    assert len(feature.datasets) > 0, f"{feature} has no datasets"
 
 
 def test_images_datasets_names():
     start = time.time()
-    all_ds_names = {ds.name for f in features for ds in f.datasets}
+    all_ds_names = {ds.name for f in all_image_features for ds in f.datasets}
     end = time.time()
     duration = start - end
-    assert len(all_ds_names) == 9, "expected 9 distinct names"
+    assert len(all_ds_names) == 10, "expected 10 distinct names"  # this must be updated if new datasets are added
     assert duration < 1, "Expected getting dataset names to be less than 1s"
+
+
+# Update this as new configs are added
+query_and_results = [
+    (siibra.features.get(siibra.get_template("big brain"), "CellbodyStainedSection"), 145),
+    (siibra.features.get(siibra.get_template("big brain"), "CellBodyStainedVolumeOfInterest"), 2),
+    (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=True), 4),
+    (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=False), 161),
+    (siibra.features.get(siibra.get_region('julich 3.1', 'hoc1 left'), "CellbodyStainedSection"), 45),
+    (siibra.features.get(siibra.get_region('julich 2.9', 'hoc1 left'), "CellbodyStainedSection"), 41)
+]
+
+
+@pytest.mark.parametrize("query_results, result_len", query_and_results)
+def test_image_query_results(
+    query_results: Image,
+    result_len: int
+):
+    assert len(query_results) == result_len
 
 
 def test_color_channel_fetching():

--- a/e2e/features/image/test_image.py
+++ b/e2e/features/image/test_image.py
@@ -33,7 +33,7 @@ query_and_results = [
     (siibra.features.get(siibra.get_template("big brain"), "CellbodyStainedSection"), 145),
     (siibra.features.get(siibra.get_template("big brain"), "CellBodyStainedVolumeOfInterest"), 2),
     (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=True), 4),
-    (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=False), 161),
+    (siibra.features.get(siibra.get_template("mni152"), "image", restrict_space=False), 13),  # TODO: should this query find all the images or it is okay if bigbrain sections fail?
     (siibra.features.get(siibra.get_region('julich 3.1', 'hoc1 left'), "CellbodyStainedSection"), 45),
     (siibra.features.get(siibra.get_region('julich 2.9', 'hoc1 left'), "CellbodyStainedSection"), 41)
 ]

--- a/siibra/locations/boundingbox.py
+++ b/siibra/locations/boundingbox.py
@@ -115,12 +115,12 @@ class BoundingBox(location.Location):
     def __str__(self):
         if self.space is None:
             return (
-                f"Bounding box from ({','.join(f'{v:.2f}' for v in self.minpoint)}) mm "
-                f"to ({','.join(f'{v:.2f}' for v in self.maxpoint)}) mm"
+                f"Bounding box from ({','.join(f'{v:.2f}' for v in self.minpoint)})mm "
+                f"to ({','.join(f'{v:.2f}' for v in self.maxpoint)})mm"
             )
         else:
             return (
-                f"Bounding box from ({','.join(f'{v:.2f}' for v in self.minpoint)}) mm "
+                f"Bounding box from ({','.join(f'{v:.2f}' for v in self.minpoint)})mm "
                 f"to ({','.join(f'{v:.2f}' for v in self.maxpoint)})mm in {self.space.name} space"
             )
 

--- a/siibra/locations/boundingbox.py
+++ b/siibra/locations/boundingbox.py
@@ -297,9 +297,10 @@ class BoundingBox(location.Location):
             return self
         else:
             try:
-                return self.corners.warp(spaceobj).boundingbox
-            except ValueError:
+                warped_corners = self.corners.warp(spaceobj)
+            except SpaceWarpingFailedError:
                 raise SpaceWarpingFailedError(f"Warping {str(self)} to {spaceobj.name} not successful.")
+            return warped_corners.boundingbox
 
     def transform(self, affine: np.ndarray, space=None):
         """Returns a new bounding box obtained by transforming the

--- a/siibra/locations/boundingbox.py
+++ b/siibra/locations/boundingbox.py
@@ -188,12 +188,18 @@ class BoundingBox(location.Location):
                 result_minpt.append(A[dim])
                 result_maxpt.append(B[dim])
 
+        if result_minpt == result_maxpt:
+            return result_minpt
+
         bbox = BoundingBox(
             point1=point.Point(result_minpt, self.space),
             point2=point.Point(result_maxpt, self.space),
             space=self.space,
         )
-        return bbox if bbox.volume > 0 else None
+
+        if bbox.volume == 0 and sum(cmin == cmax for cmin, cmax in zip(result_minpt, result_maxpt)) == 2:
+            return None
+        return bbox
 
     def _intersect_mask(self, mask: 'Nifti1Image', threshold=0):
         """Intersect this bounding box with an image mask. Returns None if they do not intersect.

--- a/siibra/locations/point.py
+++ b/siibra/locations/point.py
@@ -55,10 +55,14 @@ class Point(location.Location):
             if len(digits) == 3:
                 return tuple(float(d) for d in digits)
         elif isinstance(spec, (tuple, list)) and len(spec) in [3, 4]:
+            if any(v is None for v in spec):
+                raise RuntimeError("Cannot parse cooridantes containing None values.")
             if len(spec) == 4:
                 assert spec[3] == 1
             return tuple(float(v.item()) if isinstance(v, np.ndarray) else float(v) for v in spec[:3])
         elif isinstance(spec, np.ndarray) and spec.size == 3:
+            if any(np.isnan(v) for v in spec):
+                raise RuntimeError("Cannot parse cooridantes containing NaN values.")
             return tuple(float(v.item()) if isinstance(v, np.ndarray) else float(v) for v in spec[:3])
         elif isinstance(spec, Point):
             return spec.coordinate


### PR DESCRIPTION
This PR fixes the no intersection issue when the intersection of 2 bounding boxes is planar and hence have volume 0 resulting in None. This meant that while there are some intersections, these were ignored. Also, the edge case, the intersection is just a point, is accounted for.

code to reproduce the issue on [current main](31b091200d7c3f3d041e762925ff6571d862268a)
```python
import siibra
points = siibra.PointSet(
    [
        [-35.72, -1.87, 35.03],
        [-33.7, -1.87, 36.2],
        [-32.56, -1.87, 34.34],
        [-35.62, -1.87, 35.2],
    ],
    "bigbrain",
)
matched_sections = siibra.features.get(
    points, siibra.features.cellular.CellbodyStainedSection
)
assert len(matched_sections) > 0
voi = points.boundingbox

# this is expected to fetch but fails assuming there is no intersection
patch_1mu = matched_sections[0].fetch(voi=voi, resolution_mm=-1)
```