### PR TITLE
Rounding scheme for neuroglancer fetching needs revision

### DIFF
--- a/siibra/volumes/providers/neuroglancer.py
+++ b/siibra/volumes/providers/neuroglancer.py
@@ -554,6 +554,10 @@ class NeuroglancerScale:
         x0, y0, z0 = (np.array(bbox_.minpoint) - data_min).astype("int")
         xd, yd, zd = np.ceil(bbox_.maxpoint).astype(int) - np.floor(bbox_.minpoint).astype(int)
         offset = tuple(bbox_.minpoint)
+        if voi is not None:
+            logger.debug(
+                f"Input: {voi.minpoint.coordinate}, {voi.maxpoint.coordinate}.\nVoxel space: {bbox_.minpoint.coordinate}, {bbox_.maxpoint.coordinate}"
+            )
 
         # build the nifti image
         trans = np.identity(4)[[2, 1, 0, 3], :]  # zyx -> xyz

--- a/siibra/volumes/providers/neuroglancer.py
+++ b/siibra/volumes/providers/neuroglancer.py
@@ -529,7 +529,7 @@ class NeuroglancerScale:
         if voi is None:
             bbox_ = _boundingbox.BoundingBox((0, 0, 0), self.size, space=None)
         else:
-            bbox_ = voi.transform(np.linalg.inv(self.affine))
+            bbox_ = voi.transform(np.linalg.inv(self.affine), space=None)
 
         # extract minimum and maximum the chunk indices to be loaded
         gx0, gy0, gz0 = self._point_to_lower_chunk_idx(tuple(bbox_.minpoint))
@@ -552,7 +552,7 @@ class NeuroglancerScale:
         # exact bounding box requested, to cut off undesired borders
         data_min = np.array([gx0, gy0, gz0]) * self.chunk_sizes
         x0, y0, z0 = (np.array(bbox_.minpoint) - data_min).astype("int")
-        xd, yd, zd = np.ceil(bbox_.maxpoint - bbox_.minpoint).astype("int")  # fetch full voxels
+        xd, yd, zd = np.ceil(bbox_.maxpoint).astype(int) - np.floor(bbox_.minpoint).astype(int)
         offset = tuple(bbox_.minpoint)
 
         # build the nifti image

--- a/siibra/volumes/providers/neuroglancer.py
+++ b/siibra/volumes/providers/neuroglancer.py
@@ -531,13 +531,6 @@ class NeuroglancerScale:
         else:
             bbox_ = voi.transform(np.linalg.inv(self.affine))
 
-        for dim in range(3):
-            if bbox_.shape[dim] < 1:
-                logger.warning(
-                    f"Bounding box in voxel space will be enlarged to by {self.res_mm[dim]} along axis {dim}."
-                )
-                bbox_.maxpoint[dim] = bbox_.maxpoint[dim] + self.res_mm[dim]
-
         # extract minimum and maximum the chunk indices to be loaded
         gx0, gy0, gz0 = self._point_to_lower_chunk_idx(tuple(bbox_.minpoint))
         gx1, gy1, gz1 = self._point_to_upper_chunk_idx(tuple(bbox_.maxpoint))
@@ -559,7 +552,7 @@ class NeuroglancerScale:
         # exact bounding box requested, to cut off undesired borders
         data_min = np.array([gx0, gy0, gz0]) * self.chunk_sizes
         x0, y0, z0 = (np.array(bbox_.minpoint) - data_min).astype("int")
-        xd, yd, zd = np.ceil((np.array(bbox_.maxpoint))).astype(int) - np.floor((np.array(bbox_.minpoint))).astype(int)
+        xd, yd, zd = np.ceil(bbox_.maxpoint - bbox_.minpoint).astype("int")  # fetch full voxels
         offset = tuple(bbox_.minpoint)
 
         # build the nifti image


### PR DESCRIPTION
When fetching an axis aligned flat volume of interest translating to exactly 1 voxel "thickness" in one dimension, the NeuroglancerScale fetching method rounds up to a 2 voxel array. In my example, fetching in bigbrain space with `Bounding box from (36.58,-0.10,8.33)mm to (38.64,-0.08,11.71)mm in BigBrain microscopic template (histology) space` retrieved an image array of shape (160, 2, 99).

This is critical, since several analysis workflows that I had implemented with siibra rely on the possibility to fetch a 2D patch from properly sized bounding boxes in physical coordinates, and would now confront me to resolve the ambiguity downstream.

The problem is caused by taking `floor`of the minpoint and `ceil` of the max point to compute the target shape as their difference, resulting in a doubling of integer rounding in the extreme case. The suggested change computes the rounded target shape as the `ceil` of the difference of the unrounded max- and midpoints instead, and adds it to the `floor`ed midpoint to obtain the rounded max point, therefore always only triggering a single rounding effect. Using the fix, the aforementioned bounding box yields an array of shape `(160, 1, 98)` after fetching, as expected.

The previous explicit additional clipping of voxel dimensions smaller than 1 seemed incorrect to me, and did not influence the result after the fix anyways, so I removed it.

The proposed change fixes the said problem, but it should be carefully thought through and tested on other examples. I suggest to define a range of standard and border cases of VOIs to double-check that fetching works as expected:
- perfect cube should result in perfect cube
- VOI dimensions equal or smaller to the volume's pixel size (resolution_mm) should result in flat dimensions (dim=1) of the flat array (that's the example reported above)
- VOIs larger than the volume dimensions should be clipped exactly to the max dimension of the volume
- ...

