### PR TITLE
TemplateFlow spaces as siibra objects

### DIFF
--- a/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py
+++ b/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py
@@ -24,31 +24,66 @@ Extending siibra with TemplateFlow maps and templates
 
 # %%
 import siibra
+from siibra.configuration import templateflow
 from nilearn import plotting
 
 # %%
-# TODO: delete this cell for the final notebook
-from siibra.configuration import templateflow
-
-tf = templateflow.TemplateFlow()
-tf._check_urls()
-# %%
 siibra.extend_configuration(siibra.create_templateflow_configs())
-siibra.spaces.dataframe
+for s in siibra.spaces:
+    if "[TemplateFlow]" not in s.name:
+        continue
+    print(s.species)
+    print(s.name)
 
 # %%
-MNI152NLin6Asym = siibra.spaces.get("MNI ICBM 152 non-linear 6th Generation Asymmetric")
-MNI152NLin6Asym
+MNI152NLin2009cAsym = siibra.spaces.get(
+    "[TemplateFlow] ICBM 152 Nonlinear Asymmetrical template version 2009c"
+)
+MNI152NLin2009cAsym
 
 # %%
-print(MNI152NLin6Asym.name)
-print(MNI152NLin6Asym.publications)
-print(MNI152NLin6Asym.description)
+print(MNI152NLin2009cAsym.name)
+print(MNI152NLin2009cAsym.shortname)
+print(MNI152NLin2009cAsym.publications)
+print(MNI152NLin2009cAsym.description)
 
 # %%
-for template in MNI152NLin6Asym.volumes:
+for template in MNI152NLin2009cAsym.volumes:
     print(template.variant)
 
 # %%
-tmp_img = MNI152NLin6Asym.get_template("T1w - res: 01").fetch()
+tmp_img = MNI152NLin2009cAsym.get_template("T1w - res: 01").fetch()
 plotting.view_img(tmp_img, bg_img=None, symmetric_cmap=False, cmap="gray")
+
+
+# %%
+# TEMP: this is just for testing. Eventually, the user will just get the map as
+# usual, similar to space above
+tf = templateflow.TemplateFlow()
+space_spec = MNI152NLin2009cAsym.shortname.removeprefix(
+    "[TemplateFlow] "
+)  # TODO: remove the need for this workaround
+tf.find_parcellations(space_spec)
+# %%
+parc = "Schaefer2018"
+map_type = "labelled"
+confs = tf.create_parc_and_map_configs(space_spec, parc, map_type)
+for entities, conf in confs.items():
+    print(entities)
+
+# %%
+mp = siibra.from_json(conf)
+r = mp.regions[0]
+print(r)
+for idx in mp.find_indices(r):
+    print(idx)
+    print(mp.fetch(index=idx).shape)
+
+# %%
+plotting.view_img(
+    mp.fetch(r),
+    bg_img=tmp_img,
+    symmetric_cmap=False,
+    resampling_interpolation="nearest",
+    colorbar=False,
+)

--- a/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py
+++ b/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py
@@ -1,0 +1,50 @@
+# Copyright 2018-2026
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+.. _008_008_templateflow_maps_and_templates
+:bdg-secondary:`Intermediate`
+
+Extending siibra with TemplateFlow maps and templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
+
+# %%
+import siibra
+from nilearn import plotting
+
+# %%
+siibra.extend_configuration(siibra.create_templateflow_configs())
+siibra.spaces.dataframe
+
+# %%
+MNI152NLin6Asym = siibra.spaces.get(
+    "MNI ICBM 152 non-linear 6th Generation Asymmetric"
+)
+MNI152NLin6Asym
+
+# %%
+print(MNI152NLin6Asym.name)
+print(MNI152NLin6Asym.publications)
+print(MNI152NLin6Asym.description)
+
+# %%
+for template in MNI152NLin6Asym.volumes:
+    print(template.variant)
+
+# %%
+tmp_img = MNI152NLin6Asym.get_template("T1 weighted (res-01)").fetch()
+plotting.view_img(tmp_img, bg_img=None, symmetric_cmap=False, cmap="gray")

--- a/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py
+++ b/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py
@@ -27,13 +27,17 @@ import siibra
 from nilearn import plotting
 
 # %%
+# TODO: delete this cell for the final notebook
+from siibra.configuration import templateflow
+
+tf = templateflow.TemplateFlow()
+tf._check_urls()
+# %%
 siibra.extend_configuration(siibra.create_templateflow_configs())
 siibra.spaces.dataframe
 
 # %%
-MNI152NLin6Asym = siibra.spaces.get(
-    "MNI ICBM 152 non-linear 6th Generation Asymmetric"
-)
+MNI152NLin6Asym = siibra.spaces.get("MNI ICBM 152 non-linear 6th Generation Asymmetric")
 MNI152NLin6Asym
 
 # %%
@@ -46,5 +50,5 @@ for template in MNI152NLin6Asym.volumes:
     print(template.variant)
 
 # %%
-tmp_img = MNI152NLin6Asym.get_template("T1 weighted (res-01)").fetch()
+tmp_img = MNI152NLin6Asym.get_template("T1w - res: 01").fetch()
 plotting.view_img(tmp_img, bg_img=None, symmetric_cmap=False, cmap="gray")

--- a/siibra/__init__.py
+++ b/siibra/__init__.py
@@ -24,7 +24,7 @@ from .commons import (
     __version__
 )
 from . import configuration, features, livequeries
-from .configuration import factory
+from .configuration import factory, create_templateflow_configs
 from .core import (
     atlas as _atlas,
     parcellation as _parcellation,
@@ -280,4 +280,5 @@ def __dir__():
         "warm_cache",
         "set_cache_size",
         "from_json",
+        "create_templateflow_configs",
     ]

--- a/siibra/configuration/__init__.py
+++ b/siibra/configuration/__init__.py
@@ -15,3 +15,4 @@
 """Handles reconfiguration management and building instances"""
 
 from .configuration import Configuration
+from .templateflow import create_local_repository as create_templateflow_configs

--- a/siibra/configuration/templateflow.py
+++ b/siibra/configuration/templateflow.py
@@ -1,0 +1,253 @@
+# Copyright 2018-2026
+# Institute of Neuroscience and Medicine (INM-1), Forschungszentrum Jülich GmbH
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pathlib
+import hashlib
+from urllib.parse import quote
+from zipfile import ZipFile
+import json
+
+from ..commons import logger, Species
+from ..retrieval.cache import CACHE
+from ..retrieval.requests import HttpRequest
+from ..retrieval.repositories import LocalFileRepository
+
+SKELETON_URL = (
+    "https://raw.githubusercontent.com/templateflow/python-client/"
+    "{revision}/templateflow/conf/templateflow-skel.zip"
+)
+TEMPLATEFLOW_S3 = "https://templateflow.s3.amazonaws.com"
+TEMPLATE_VARIANTS = {
+    "T1w": "T1 weighted",
+    "T2w": "T2 weighted",
+    "T1map": "T1 map",
+    "T2map": "T2 map",
+    "T2star": "T2*",
+    "PD": "proton density",
+    "FLAIR": "FLAIR",
+}
+
+NIFTI_EXTENSIONS = ("nii.gz", "nii")
+
+MAP_EXTENSIONS = {
+    "dseg",
+    "probseg",
+}
+
+TEMPLATE_EXTENSIONS = {
+    "T1w",
+    "T2w",
+    "T1map",
+    "T2map",
+    "T2star",
+    "PD",
+    "FLAIR",
+}
+
+TEMPLATEFLOW_CITATION = (
+    "TemplateFlow: a community archive of imaging templates and atlases for "
+    "improved consistency in neuroimaging R Ciric, R Lorenz, WH Thompson, M "
+    "Goncalves, E MacNicol, CJ Markiewicz, YO Halchenko, SS Ghosh, KJ "
+    "Gorgolewski, RA Poldrack, O Esteban bioRxiv 2021.02.10.430678; "
+    "doi:10.1101/2021.02.10.430678"
+)
+
+
+class TemplateFlow:
+
+    @staticmethod
+    def classify_templateflow_files(
+        revision: str = "master",
+    ) -> dict[str, dict[str, list[str]]]:
+        """Classify TemplateFlow templates, maps, and map TSV files."""
+        spaces = {}
+        req = HttpRequest(SKELETON_URL.format(revision=revision))
+        with req.get() as archive:
+            assert isinstance(archive, ZipFile)
+
+            cohort_divided = {
+                f.filename.split("/")[0]: None
+                for f in archive.filelist
+                if f.is_dir() and "cohort" in f.filename
+            }
+
+            spaces = {}
+            for f in archive.filelist:
+                if not f.is_dir() or "scripts" in f.filename:
+                    continue
+
+                parts = f.filename.split("/")
+                key = parts[0]
+                if key in cohort_divided and "cohort" in parts[1]:
+                    spaces[f"{key}/{parts[1]}"] = spaces[key]
+                else:
+                    desc_file = f.filename + "template_description.json"
+                    with archive.open(desc_file, "r") as fp:
+                        description = json.load(fp=fp)
+                    try:
+                        license = archive.read(f.filename + "LICENSE").decode()
+                    except KeyError:
+                        license = description.get("License", "No license information was found.")
+
+                    spaces.setdefault(
+                        key,
+                        {
+                            "license": license,
+                            "description": description,
+                            "templates": {},
+                            "maps": [],
+                            "tsvs": [],
+                        },
+                    )
+
+            # remove top level key for templates divided by cohorts
+            for key in cohort_divided.keys():
+                spaces.pop(key)
+
+            for f in archive.filelist:
+                if f.is_dir():
+                    continue
+
+                parts = f.filename.split("/")
+                key = parts[0]
+                if key in cohort_divided and "cohort" in parts[1]:
+                    key = f"{key}/{parts[1]}"
+
+                parts = f.filename.split(".")
+                suffix = ".".join(parts[1:])
+                entities = parts[0].split("_")
+                bids_extension = entities[-1]
+
+                if suffix == "tsv":
+                    if key in spaces:
+                        spaces[key]["tsvs"].append(f.filename)
+                    else:
+                        for k in spaces.keys():
+                            if k.startswith(key):
+                                spaces[k]["tsvs"].append(f.filename)
+                    continue
+
+                if suffix not in NIFTI_EXTENSIONS:
+                    continue
+
+                if bids_extension in MAP_EXTENSIONS:
+                    spaces[key]["maps"].append(f.filename)
+                if bids_extension in TEMPLATE_EXTENSIONS:
+                    variant = TEMPLATE_VARIANTS.get(bids_extension)
+                    qualifiers = [
+                        ent
+                        for ent in entities[:-1]
+                        if ent.startswith(("res-", "desc-"))
+                    ]
+                    if qualifiers:
+                        variant += f" ({'_'.join(qualifiers)})"
+                    spaces[key]["templates"][variant] = f.filename
+
+        return spaces
+
+    def __init__(self, revision: str = "master"):
+        self.revision = revision
+        self._skeleton_cache = self.classify_templateflow_files(revision=revision)
+        logger.info((
+            "Please cite TemplateFlow if you use it in your research:\n"
+            f"{TEMPLATEFLOW_CITATION}"
+        ))
+
+    @property
+    def citation(self):
+        return TEMPLATEFLOW_CITATION
+
+    @staticmethod
+    def _get_url(path: str) -> str:
+        return f"{TEMPLATEFLOW_S3}/" f"{quote(path, safe='/')}"
+
+    def create_space_config(self, tf_key: str):
+        description = self._skeleton_cache[tf_key]["description"]
+        species = description.get("Species")
+        name = description.get("Name")
+        try:
+            Species.decode(species)
+        except ValueError as e:
+            logger.info(
+                f"Species '{species}' is not yet supported by siibra. Skipping '{name}'"
+            )
+            raise e
+
+        uuid = hashlib.md5(str(description).encode("utf-8")).hexdigest()
+        volumes = [
+            {
+                "@type": "siibra/volume/v0.0.1",
+                "variant": variant,
+                "providers": {
+                    "nii": self._get_url(path),
+                },
+            }
+            for variant, path in self._skeleton_cache[tf_key].get("templates").items()
+        ]
+        config = {
+            "@type": "siibra/space/v0.0.1",
+            "@id": "minds/core/referencespace/v1.0.0/" f"templateflow/{uuid}",
+            "name": f"[TemplateFlow] {name}",
+            "shortName": f"TemplateFlow: {tf_key}",
+            "modality": "MRI",
+            "species": species,
+            "volumes": volumes,
+            "license": self._skeleton_cache[tf_key].get("license"),
+            "description": (
+                "This reference space was generated automatically by siibra "
+                f"from the TemplateFlow template:\n'{description}'."
+            ),
+            "publications": self._publications_from_description(description),
+        }
+        return config
+
+    @staticmethod
+    def _publications_from_description(description: dict) -> list[dict[str, str]]:
+        references = description.get("ReferencesAndLinks", [])
+
+        if isinstance(references, dict):
+            references = references.values()
+        elif isinstance(references, str):
+            references = [references]
+
+        return [
+            {"url": reference}
+            for reference in references
+            if isinstance(reference, str)
+            and reference.startswith(("https://", "http://"))
+        ]
+
+
+def create_local_repository(revision: str = "master") -> LocalFileRepository:
+    tf_config_path = pathlib.Path(f"{CACHE.folder}/TemplateFlow-{revision}")
+    tf_config_path.joinpath("spaces").mkdir(exist_ok=True, parents=True)
+    tf_config_path.joinpath("maps").mkdir(exist_ok=True, parents=True)
+    tf_config_path.joinpath("parcellations").mkdir(exist_ok=True, parents=True)
+    tf = TemplateFlow(revision=revision)
+    for key in tf._skeleton_cache:
+        try:
+            space_conf = tf.create_space_config(key)
+        except ValueError:
+            continue
+        with open(
+            f"{tf_config_path}/spaces/{key.replace('/', '_')}.json",
+            mode="wt",
+            encoding="utf-8",
+        ) as fp:
+            json.dump(space_conf, indent="\t", fp=fp)
+            fp.write("\n")
+
+    return LocalFileRepository(tf_config_path)

--- a/siibra/configuration/templateflow.py
+++ b/siibra/configuration/templateflow.py
@@ -22,6 +22,8 @@ import json
 from typing import Union, Literal, List, Dict
 from dataclasses import dataclass
 
+import pandas as pd
+
 from ..commons import logger, Species
 from ..retrieval.cache import CACHE
 from ..retrieval.requests import HttpRequest
@@ -83,6 +85,15 @@ TEMPLATEFLOW_CITATION = (
     "Gorgolewski, RA Poldrack, O Esteban bioRxiv 2021.02.10.430678; "
     "doi:10.1101/2021.02.10.430678"
 )
+TSV_INDEX_HEADERS = {
+    "index",
+    "Index",
+    "label",
+}
+TSV_NAME_HEADERS = {
+    "name",
+    "structure",
+}
 
 
 @dataclass
@@ -99,11 +110,7 @@ class TemplateFlowFile:
     def url(self):
         return f"{TEMPLATEFLOW_S3}/" f"{quote(self.filepath, safe='/')}"
 
-    def parcellation_spec(self):
-        if self.siibra_type == "map":
-            return self.entities.get("atlas", self.space.removeprefix("tpl-"))
-        raise ValueError("Parcellation spec is only applicable to `map` types.")
-
+    @property
     def volume_spec(self):
         if self.siibra_type == "map":
             specs = [f"{k}: {v}" for k, v in self.entities.items() if k != "atlas"]
@@ -196,12 +203,26 @@ class TemplateFlow:
     def spaces(self):
         return sorted(list(set(f.space for f in self._files)))
 
-    def find_parcellations(self, space: str):
-        assert space in self.spaces
-        return sorted(list({
-            f.parcellation_spec()
-            for f in self.ls_map_files(space)
-        }))
+    def find_parcellations(self, space: Union[str, None] = None):
+        assert space is None or space in self.spaces
+        return sorted(
+            list({f.entities.get("atlas", f.space) for f in self.ls_map_files(space)})
+        )
+
+    def _find_lut_files(
+        self,
+        space: str,
+        parecellation: str,
+        bids_map_type: Literal["dseg", "probseg"],
+    ):
+        tsvs = [
+            fn
+            for fn in self.skeleton_archive.namelist()
+            if fn.endswith(f"{bids_map_type}.tsv")
+            and fn.startswith(f"tpl-{space}")
+            and parecellation in fn
+        ]
+        return tsvs
 
     def ls_template_files(
         self, space: Union[str, None] = None
@@ -215,14 +236,16 @@ class TemplateFlow:
     def ls_map_files(
         self,
         space: Union[str, None] = None,
-        maptype: Union[Literal["labelled", "statistical"], None] = None,
+        parcellation: Union[str, None] = None,
+        map_type: Union[Literal["labelled", "statistical"], None] = None,
     ) -> List[TemplateFlowFile]:
         return list(
             f
             for f in self._files
             if f.siibra_type == "map"
             and (space is None or f.space == space)
-            and (maptype is None or f.modality == maptype)
+            and (parcellation is None or parcellation in f.filepath)
+            and (map_type is None or f.modality == map_type)
         )
 
     def _check_urls(self):
@@ -255,7 +278,7 @@ class TemplateFlow:
         volumes = [
             {
                 "@type": "siibra/volume/v0.0.1",
-                "variant": tf_file.volume_spec(),
+                "variant": tf_file.volume_spec,
                 "providers": {
                     tf_file.provider_type: tf_file.url,
                 },
@@ -264,9 +287,9 @@ class TemplateFlow:
         ]
         config = {
             "@type": "siibra/space/v0.0.1",
-            "@id": "minds/core/referencespace/v1.0.0/" f"templateflow/{uuid}",
+            "@id": f"minds/core/referencespace/v1.0.0/templateflow-{self.revision}/{uuid}",
             "name": f"[TemplateFlow] {name}",
-            "shortName": f"TemplateFlow: {space}",
+            "shortName": f"[TemplateFlow] {space.removeprefix('tpl-')}",
             "modality": "MRI",
             "species": species,
             "volumes": volumes,
@@ -279,11 +302,114 @@ class TemplateFlow:
         }
         return config
 
-    def create_map_config(self, space: str, parcellation_spec: str):
-        pass
+    def create_parc_and_map_configs(
+        self,
+        space: str,
+        parcellation: str,
+        map_type: Literal["labelled", "statistical"],
+    ):
+        tsv_mapping = self._find_maps(
+            space=space,
+            parcellation=parcellation,
+            map_type=map_type,
+        )
+
+        def get_conf_base(tsv_entities: List[str]):
+            sub_parc_name = "[TemplateFlow] " + " - ".join(tsv_entities)
+            uuid = hashlib.md5(f"{space}:{sub_parc_name}".encode("utf-8")).hexdigest()
+            return {
+                "@type": "siibra/map/v0.0.1",
+                "@id": f"siibra-map-v0.0.templateflow-{self.revision}_{uuid}",
+                "name": sub_parc_name,
+                "space": {"name": self.get_description(space=space)["Name"]},
+                "parcellation": {"name": sub_parc_name},
+                **(
+                    {"represented_as:_sparsemap": True}
+                    if map_type == "statistical"
+                    else {}
+                ),
+            }
+
+        configs = {}
+        for tsv, meta in tsv_mapping.items():
+            with self.skeleton_archive.open(tsv) as fp:
+                lut = pd.read_csv(fp, sep="\t")
+
+            for index_col in TSV_INDEX_HEADERS:
+                if index_col in lut.columns:
+                    break
+            else:
+                continue
+            for region_col in TSV_NAME_HEADERS:
+                if region_col in lut.columns:
+                    break
+            else:
+                continue
+
+            key = tuple(meta["entities"])
+            configs[key] = {
+                **get_conf_base(meta["entities"]),
+                "volumes": [],
+                "indices": {
+                    getattr(row, region_col): []
+                    for row in lut.itertuples()
+                },
+            }
+            for v_idx, v in enumerate(meta["volumes"]):
+                configs[key]["volumes"].append(
+                    {
+                        "@type": "siibra/volume/v0.0.1",
+                        "providers": {"nii": v.url}
+                    }
+                )
+                for row in lut.itertuples():
+                    configs[key]["indices"][getattr(row, region_col)].append(
+                        {"volume": v_idx, "label": getattr(row, index_col)}
+                    )
+
+        return configs
+
+    def _find_maps(
+        self,
+        space: str,
+        parcellation: str,
+        map_type: Literal["labelled", "statistical"],
+    ) -> Dict[str, List["TemplateFlowFile"]]:
+        if map_type == "labelled":
+            bids_map_type = "dseg"
+        if map_type == "statistical":
+            bids_map_type = "probseg"
+
+        tsvs = [
+            fn
+            for fn in self.skeleton_archive.namelist()
+            if fn.endswith(f"{bids_map_type}.tsv")
+            and fn.startswith(f"tpl-{space}")
+            and parcellation in fn
+        ]
+        if len(tsvs) == 0:
+            raise ValueError
+
+        map_files = self.ls_map_files(
+            space=space, parcellation=parcellation, map_type=map_type
+        )
+
+        tsv_mapping = {}
+        for tsv in tsvs:
+            entities = tsv.split("/")[-1].split(".")[0].split("_")[1:]
+            tsv_mapping[tsv] = {
+                "entities": entities,
+                "volumes": [
+                    mf
+                    for mf in map_files
+                    if all(ent in mf.filepath for ent in entities)
+                ],
+            }
+
+        return tsv_mapping
 
     def get_description(self, space: str) -> dict:
-        desc_file = f"{space}/template_description.json"
+        desc_file = f"tpl-{space}/template_description.json"
         with self.skeleton_archive.open(desc_file, "r") as fp:
             description = json.load(fp=fp)
         return description
@@ -333,7 +459,7 @@ def create_local_repository(
         try:
             space_conf = tf.create_space_config(space)
             filename = f"TemplateFlow-{space}.json"
-        except ValueError:
+        except (ValueError, KeyError):
             continue
         with open(
             f"{tf_config_path}/spaces/{filename}",
@@ -342,5 +468,37 @@ def create_local_repository(
         ) as fp:
             json.dump(space_conf, indent="\t", fp=fp)
             fp.write("\n")
+
+    # maps and parcellations
+    for space in tf.spaces:
+        continue
+        parcs = tf.find_parcellations(space=space)
+        for parc in parcs:
+            for mt in ["labelled", "statistical"]:
+                try:
+                    map_confs = tf.create_parc_and_map_configs(
+                        space=space, parcellation=parc, map_type=mt,
+                    )
+                except ValueError:
+                    continue
+
+            # parc_filename = f"TemplateFlow-{parc}.json"
+            # with open(
+            #     f"{tf_config_path}/maps/{parc_filename}",
+            #     mode="wt",
+            #     encoding="utf-8",
+            # ) as fp:
+            #     json.dump(parc_conf, indent="\t", fp=fp)
+            #     fp.write("\n")
+
+            for map_conf in map_confs:
+                map_filename = f"{map_conf['name']}.json"
+                with open(
+                    f"{tf_config_path}/maps/{map_filename}",
+                    mode="wt",
+                    encoding="utf-8",
+                ) as fp:
+                    json.dump(map_conf, indent="\t", fp=fp)
+                    fp.write("\n")
 
     return LocalFileRepository(tf_config_path)

--- a/siibra/configuration/templateflow.py
+++ b/siibra/configuration/templateflow.py
@@ -186,7 +186,7 @@ class TemplateFlow:
             )
             raise e
 
-        uuid = hashlib.md5(str(description).encode("utf-8")).hexdigest()
+        uuid = hashlib.md5(f"{tf_key}:{description}".encode("utf-8")).hexdigest()
         volumes = [
             {
                 "@type": "siibra/volume/v0.0.1",

--- a/siibra/configuration/templateflow.py
+++ b/siibra/configuration/templateflow.py
@@ -19,6 +19,8 @@ import hashlib
 from urllib.parse import quote
 from zipfile import ZipFile
 import json
+from typing import Union, Literal, List, Dict
+from dataclasses import dataclass
 
 from ..commons import logger, Species
 from ..retrieval.cache import CACHE
@@ -30,23 +32,11 @@ SKELETON_URL = (
     "{revision}/templateflow/conf/templateflow-skel.zip"
 )
 TEMPLATEFLOW_S3 = "https://templateflow.s3.amazonaws.com"
-TEMPLATE_VARIANTS = {
-    "T1w": "T1 weighted",
-    "T2w": "T2 weighted",
-    "T1map": "T1 map",
-    "T2map": "T2 map",
-    "T2star": "T2*",
-    "PD": "proton density",
-    "FLAIR": "FLAIR",
-}
-
-NIFTI_EXTENSIONS = ("nii.gz", "nii")
-
 MAP_EXTENSIONS = {
-    "dseg",
-    "probseg",
+    "dseg": "labelled",
+    "dparc": "labelled",
+    "probseg": "statistical",
 }
-
 TEMPLATE_EXTENSIONS = {
     "T1w",
     "T2w",
@@ -54,9 +44,38 @@ TEMPLATE_EXTENSIONS = {
     "T2map",
     "T2star",
     "PD",
+    "PDw",
     "FLAIR",
+    "boldref",
+    "epi",
+    "UNIT1",
+    "SPECT",
+    "PET",
+    "MP2RAGE",
+    "MD",
+    "FA",
+    "veryinflated",
+    "inflated",
+    "sphere",
+    "pial",
+    "thickness",
+    "midthickness",
+    "flat",
+    "sulc",
+    "white",
+    "roi",
+    "curv",
+    "myelinmap",
+    "area",
+    "mask",
 }
-
+SUPPORTED_FILE_FORMATS = {
+    "nii.gz": "nii",
+    "nii": "nii",
+    "label.gii": "gii-label",
+    "surf.gii": "gii-mesh",
+    "gii": "gii-label",
+}
 TEMPLATEFLOW_CITATION = (
     "TemplateFlow: a community archive of imaging templates and atlases for "
     "improved consistency in neuroimaging R Ciric, R Lorenz, WH Thompson, M "
@@ -66,116 +85,162 @@ TEMPLATEFLOW_CITATION = (
 )
 
 
+@dataclass
+class TemplateFlowFile:
+    space: str
+    cohort: Union[str, None]
+    filepath: str
+    entities: Dict[str, str]
+    provider_type: str
+    siibra_type: Literal["map", "template"]
+    modality: str
+
+    @property
+    def url(self):
+        return f"{TEMPLATEFLOW_S3}/" f"{quote(self.filepath, safe='/')}"
+
+    def parcellation_spec(self):
+        if self.siibra_type == "map":
+            return self.entities.get("atlas", self.space.removeprefix("tpl-"))
+        raise ValueError("Parcellation spec is only applicable to `map` types.")
+
+    def volume_spec(self):
+        if self.siibra_type == "map":
+            specs = [f"{k}: {v}" for k, v in self.entities.items() if k != "atlas"]
+            return " - ".join(specs)
+        if self.siibra_type == "template":
+            specs = [f"{k}: {v}" for k, v in self.entities.items()]
+            return " - ".join([self.modality] + specs)
+
+        raise ValueError(f"Invalid siibra_type: {self.siibra_type}")
+
+
+@dataclass
 class TemplateFlow:
+    revision: str = "master"
 
-    @staticmethod
-    def classify_templateflow_files(
-        revision: str = "master",
-    ) -> dict[str, dict[str, list[str]]]:
-        """Classify TemplateFlow templates, maps, and map TSV files."""
-        spaces = {}
-        req = HttpRequest(SKELETON_URL.format(revision=revision))
-        with req.get() as archive:
-            assert isinstance(archive, ZipFile)
+    def __post_init__(self):
+        self._files: List["TemplateFlowFile"] = self.classify_templateflow_files()
+        logger.info(
+            (
+                "Please cite TemplateFlow if you use it in your research:\n"
+                f"{TEMPLATEFLOW_CITATION}"
+            )
+        )
 
-            cohort_divided = {
-                f.filename.split("/")[0]: None
-                for f in archive.filelist
-                if f.is_dir() and "cohort" in f.filename
-            }
+    @property
+    def skeleton_archive(self) -> ZipFile:
+        req = HttpRequest(SKELETON_URL.format(revision=self.revision))
+        return req.get()
 
-            spaces = {}
+    def classify_templateflow_files(self):
+        files: List["TemplateFlowFile"] = []
+        with self.skeleton_archive as archive:
             for f in archive.filelist:
-                if not f.is_dir() or "scripts" in f.filename:
+                if not any(f.filename.endswith(s) for s in SUPPORTED_FILE_FORMATS):
                     continue
 
                 parts = f.filename.split("/")
-                key = parts[0]
-                if key in cohort_divided and "cohort" in parts[1]:
-                    spaces[f"{key}/{parts[1]}"] = spaces[key]
+                for part in parts[:-1]:
+                    if "cohort" in part.lower():
+                        cohort = part
+                        break
                 else:
-                    desc_file = f.filename + "template_description.json"
-                    with archive.open(desc_file, "r") as fp:
-                        description = json.load(fp=fp)
-                    try:
-                        license = archive.read(f.filename + "LICENSE").decode()
-                    except KeyError:
-                        license = description.get("License", "No license information was found.")
+                    cohort = None
 
-                    spaces.setdefault(
-                        key,
-                        {
-                            "license": license,
-                            "description": description,
-                            "templates": {},
-                            "maps": [],
-                            "tsvs": [],
-                        },
-                    )
+                fname = parts[-1]
+                stem, *suffixes = fname.split(".")
+                entities = stem.split("_")
+                space = entities[0].removeprefix("tpl-")
+                if "desc-" in entities[-1]:
+                    bids_modality_suffix = None
+                else:
+                    bids_modality_suffix = entities[-1]
+                entities = (
+                    entities[1:] if bids_modality_suffix is None else entities[1:-1]
+                )
 
-            # remove top level key for templates divided by cohorts
-            for key in cohort_divided.keys():
-                spaces.pop(key)
-
-            for f in archive.filelist:
-                if f.is_dir():
-                    continue
-
-                parts = f.filename.split("/")
-                key = parts[0]
-                if key in cohort_divided and "cohort" in parts[1]:
-                    key = f"{key}/{parts[1]}"
-
-                parts = f.filename.split(".")
-                suffix = ".".join(parts[1:])
-                entities = parts[0].split("_")
-                bids_extension = entities[-1]
-
-                if suffix == "tsv":
-                    if key in spaces:
-                        spaces[key]["tsvs"].append(f.filename)
+                if bids_modality_suffix in MAP_EXTENSIONS:
+                    siibra_type = "map"
+                    modality_suffix = MAP_EXTENSIONS[bids_modality_suffix]
+                elif bids_modality_suffix in TEMPLATE_EXTENSIONS:
+                    siibra_type = "template"
+                    modality_suffix = bids_modality_suffix
+                else:
+                    if fname.endswith("label.gii"):
+                        siibra_type = "map"
+                        modality_suffix = "labelled"
                     else:
-                        for k in spaces.keys():
-                            if k.startswith(key):
-                                spaces[k]["tsvs"].append(f.filename)
-                    continue
+                        logger.warning(f"Unknown BIDS suffix: {fname}")
 
-                if suffix not in NIFTI_EXTENSIONS:
-                    continue
+                provider_type = SUPPORTED_FILE_FORMATS.get(".".join(suffixes))
+                if provider_type is None and "gii" in suffixes:
+                    provider_type = "gii-label"  # TODO: allow digesting other gii files
+                files.append(
+                    TemplateFlowFile(
+                        space=space,
+                        filepath=f.filename,
+                        provider_type=provider_type,
+                        entities={
+                            ent.split("-")[0]: ent.split("-")[1] for ent in entities
+                        },
+                        siibra_type=siibra_type,
+                        modality=modality_suffix,
+                        cohort=cohort,
+                    )
+                )
 
-                if bids_extension in MAP_EXTENSIONS:
-                    spaces[key]["maps"].append(f.filename)
-                if bids_extension in TEMPLATE_EXTENSIONS:
-                    variant = TEMPLATE_VARIANTS.get(bids_extension)
-                    qualifiers = [
-                        ent
-                        for ent in entities[:-1]
-                        if ent.startswith(("res-", "desc-"))
-                    ]
-                    if qualifiers:
-                        variant += f" ({'_'.join(qualifiers)})"
-                    spaces[key]["templates"][variant] = f.filename
+        return files
 
-        return spaces
+    @property
+    def spaces(self):
+        return sorted(list(set(f.space for f in self._files)))
 
-    def __init__(self, revision: str = "master"):
-        self.revision = revision
-        self._skeleton_cache = self.classify_templateflow_files(revision=revision)
-        logger.info((
-            "Please cite TemplateFlow if you use it in your research:\n"
-            f"{TEMPLATEFLOW_CITATION}"
-        ))
+    def find_parcellations(self, space: str):
+        assert space in self.spaces
+        return sorted(list({
+            f.parcellation_spec()
+            for f in self.ls_map_files(space)
+        }))
+
+    def ls_template_files(
+        self, space: Union[str, None] = None
+    ) -> List[TemplateFlowFile]:
+        return list(
+            f
+            for f in self._files
+            if f.siibra_type == "template" and (space is None or f.space == space)
+        )
+
+    def ls_map_files(
+        self,
+        space: Union[str, None] = None,
+        maptype: Union[Literal["labelled", "statistical"], None] = None,
+    ) -> List[TemplateFlowFile]:
+        return list(
+            f
+            for f in self._files
+            if f.siibra_type == "map"
+            and (space is None or f.space == space)
+            and (maptype is None or f.modality == maptype)
+        )
+
+    def _check_urls(self):
+        import requests
+
+        for f in self._files:
+            req = requests.get(f.url, stream=True)
+            try:
+                req.raise_for_status()
+            except Exception as e:
+                print(e)
 
     @property
     def citation(self):
         return TEMPLATEFLOW_CITATION
 
-    @staticmethod
-    def _get_url(path: str) -> str:
-        return f"{TEMPLATEFLOW_S3}/" f"{quote(path, safe='/')}"
-
-    def create_space_config(self, tf_key: str):
-        description = self._skeleton_cache[tf_key]["description"]
+    def create_space_config(self, space: str):
+        description = self.get_description(space=space)
         species = description.get("Species")
         name = description.get("Name")
         try:
@@ -186,26 +251,26 @@ class TemplateFlow:
             )
             raise e
 
-        uuid = hashlib.md5(f"{tf_key}:{description}".encode("utf-8")).hexdigest()
+        uuid = hashlib.md5(f"{space}:{description}".encode("utf-8")).hexdigest()
         volumes = [
             {
                 "@type": "siibra/volume/v0.0.1",
-                "variant": variant,
+                "variant": tf_file.volume_spec(),
                 "providers": {
-                    "nii": self._get_url(path),
+                    tf_file.provider_type: tf_file.url,
                 },
             }
-            for variant, path in self._skeleton_cache[tf_key].get("templates").items()
+            for tf_file in self.ls_template_files(space)
         ]
         config = {
             "@type": "siibra/space/v0.0.1",
             "@id": "minds/core/referencespace/v1.0.0/" f"templateflow/{uuid}",
             "name": f"[TemplateFlow] {name}",
-            "shortName": f"TemplateFlow: {tf_key}",
+            "shortName": f"TemplateFlow: {space}",
             "modality": "MRI",
             "species": species,
             "volumes": volumes,
-            "license": self._skeleton_cache[tf_key].get("license"),
+            "license": self.get_license(space=space),
             "description": (
                 "This reference space was generated automatically by siibra "
                 f"from the TemplateFlow template:\n'{description}'."
@@ -213,6 +278,23 @@ class TemplateFlow:
             "publications": self._publications_from_description(description),
         }
         return config
+
+    def create_map_config(self, space: str, parcellation_spec: str):
+        pass
+
+    def get_description(self, space: str) -> dict:
+        desc_file = f"{space}/template_description.json"
+        with self.skeleton_archive.open(desc_file, "r") as fp:
+            description = json.load(fp=fp)
+        return description
+
+    def get_license(self, space: str) -> str:
+        try:
+            return self.skeleton_archive.read(f"{space}/LICENSE").decode()
+        except KeyError:
+            return self.get_description(space).get(
+                "License", "No license information was found."
+            )
 
     @staticmethod
     def _publications_from_description(description: dict) -> list[dict[str, str]]:
@@ -231,19 +313,30 @@ class TemplateFlow:
         ]
 
 
-def create_local_repository(revision: str = "master") -> LocalFileRepository:
-    tf_config_path = pathlib.Path(f"{CACHE.folder}/TemplateFlow-{revision}")
+def create_local_repository(
+    revision: str = "master",
+    *,
+    output_folder: Union[str, pathlib.Path, None] = None,
+) -> LocalFileRepository:
+    tf_config_path = pathlib.Path(
+        f"{CACHE.folder}/TemplateFlow-{revision}"
+        if output_folder is None
+        else output_folder
+    )
     tf_config_path.joinpath("spaces").mkdir(exist_ok=True, parents=True)
     tf_config_path.joinpath("maps").mkdir(exist_ok=True, parents=True)
     tf_config_path.joinpath("parcellations").mkdir(exist_ok=True, parents=True)
     tf = TemplateFlow(revision=revision)
-    for key in tf._skeleton_cache:
+
+    # spaces
+    for space in tf.spaces:
         try:
-            space_conf = tf.create_space_config(key)
+            space_conf = tf.create_space_config(space)
+            filename = f"TemplateFlow-{space}.json"
         except ValueError:
             continue
         with open(
-            f"{tf_config_path}/spaces/{key.replace('/', '_')}.json",
+            f"{tf_config_path}/spaces/{filename}",
             mode="wt",
             encoding="utf-8",
         ) as fp:

--- a/siibra/volumes/parcellationmap.py
+++ b/siibra/volumes/parcellationmap.py
@@ -1024,7 +1024,7 @@ class Map(concept.AtlasConcept, configuration_folder="maps"):
                         "intersection over union": a.intersection_over_union,
                         "map value": a.map_value,
                         "map weighted mean": a.weighted_mean_of_first,
-                        "map containedness": a.intersection_over_first,
+                        "map containedness": a.intersection_over_first,  # intersection over input. how much of the map is inside the input
                         "input weighted mean": a.weighted_mean_of_second,
                         "input containedness": a.intersection_over_second,
                     }


### PR DESCRIPTION
Addresses #546

- [x] spaces (volumes)
- [ ] spaces (surfaces)
- [ ] labelled maps
- [ ] statistical maps

Note: some spaces are divided in cohorts which seem to be distinct enough that they could be represent with their own space configuration. This is what I chose for now since variant has to be used for other things such as image modality, resolution, and other descriptive attributes.

[Suggested typical workflow example](https://github.com/FZJ-INM1-BDA/siibra-python/blob/2ea9bea4ed12e0309eb6f5ac184a1bfff5100cb7/examples/02_maps_and_templates/008_templateflow_maps_and_templates.py)
```python
import siibra
from nilearn import plotting

siibra.extend_configuration(siibra.create_templateflow_configs())
siibra.spaces.dataframe

MNI152NLin6Asym = siibra.spaces.get(
    "MNI ICBM 152 non-linear 6th Generation Asymmetric"
)
MNI152NLin6Asym

print(MNI152NLin6Asym.name)
print(MNI152NLin6Asym.publications)
print(MNI152NLin6Asym.description)

for template in MNI152NLin6Asym.volumes:
    print(template.variant)

tmp_img = MNI152NLin6Asym.get_template("T1 weighted (res-01)").fetch()
plotting.view_img(tmp_img, bg_img=None, symmetric_cmap=False, cmap="gray")
```

List all template flow spaces
```python
import siibra
siibra.extend_configuration(siibra.create_templateflow_configs())
for s in siibra.spaces:
    if s.name.startswith("[TemplateFlow]"):
        print(s)
```