### PR TITLE
Maint configuration loading

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: "[Docs] Build docs and upload artifacts"
 
 on:
   push:
-    branches: ["main", "doc_*", "v1"]
+    branches: ["main", "doc_*", "v1", "maint_configuration_loading"]
   release:
     types: ["published"]
 

--- a/siibra/configuration/configuration.py
+++ b/siibra/configuration/configuration.py
@@ -43,7 +43,8 @@ class Configuration:
             server_or_owner,
             project_or_repo,
             reftag="siibra-{}".format(__version__),
-            skip_branchtest=True
+            skip_branchtest=True,
+            archive_mode=True,
         )
         for conn, server_or_owner, project_or_repo in CONFIG_REPOS
     ]

--- a/siibra/retrieval/repositories.py
+++ b/siibra/retrieval/repositories.py
@@ -209,6 +209,13 @@ class GithubConnector(RepositoryConnector):
         self._recursed_tree = None
 
     def search_files(self, folder="", suffix="", recursive=False) -> List[str]:
+        if self.archive_mode:
+            self._archive()
+            return self._archive_conn.search_files(
+                folder=folder,
+                suffix=suffix,
+                recursive=recursive,
+            )
         if self._recursed_tree is None:
             self._recursed_tree = HttpRequest(
                 f"{self.base_url}/git/trees/{self.reftag}?recursive=1",
@@ -241,8 +248,12 @@ class GithubConnector(RepositoryConnector):
             import tarfile
 
             tarball_url = f"{self.base_url}/tarball/{self.reftag}"
-            req = HttpRequest(tarball_url, func=lambda b: b)
-            req.get()
+            req = HttpRequest(
+                tarball_url,
+                func=lambda b: b,
+                msg_if_not_cached=f"Archiving {self.base_url}",
+            )
+            req._retrieve()
             with tarfile.open(name=req.cachefile, mode="r:gz") as tar:
                 tar.extractall(CACHE.folder)
                 foldername = tar.getnames()[0]
@@ -313,6 +324,13 @@ class GitlabConnector(RepositoryConnector):
             return f"{self.base_url}/files/{filepath}/raw?ref={ref}"
 
     def search_files(self, folder="", suffix=None, recursive=False):
+        if self.archive_mode:
+            self._archive()
+            return self._archive_conn.search_files(
+                folder=folder,
+                suffix=suffix,
+                recursive=recursive,
+            )
         page = 1
         results = []
         while True:
@@ -347,8 +365,12 @@ class GitlabConnector(RepositoryConnector):
             import tarfile
 
             tarball_url = self.base_url + f"/archive.tar.gz?sha={ref}"
-            req = HttpRequest(tarball_url, func=lambda b: b)
-            req.get()
+            req = HttpRequest(
+                tarball_url,
+                func=lambda b: b,
+                msg_if_not_cached=f"Archiving {self.base_url}",
+            )
+            req._retrieve()
             with tarfile.open(name=req.cachefile, mode="r:gz") as tar:
                 tar.extractall(CACHE.folder)
                 foldername = tar.getnames()[0]

--- a/siibra/retrieval/repositories.py
+++ b/siibra/retrieval/repositories.py
@@ -251,7 +251,7 @@ class GithubConnector(RepositoryConnector):
             req = HttpRequest(
                 tarball_url,
                 func=lambda b: b,
-                msg_if_not_cached=f"Archiving {self.base_url}",
+                msg_if_not_cached=f"Downloading {tarball_url}",
             )
             req._retrieve()
             with tarfile.open(name=req.cachefile, mode="r:gz") as tar:
@@ -368,7 +368,7 @@ class GitlabConnector(RepositoryConnector):
             req = HttpRequest(
                 tarball_url,
                 func=lambda b: b,
-                msg_if_not_cached=f"Archiving {self.base_url}",
+                msg_if_not_cached=f"Downloading {tarball_url}",
             )
             req._retrieve()
             with tarfile.open(name=req.cachefile, mode="r:gz") as tar:

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from .repositories import GitlabConnector
 
 USER_AGENT_HEADER = {"User-Agent": f"siibra-python/{__version__}"}
+_SESSION = requests.Session()
 
 
 def read_as_bytesio(function: Callable, suffix: str, bytesio: BytesIO):
@@ -212,7 +213,7 @@ class HttpRequest:
             key: self.kwargs[key] for key in self.kwargs if key != "headers"
         }
 
-        http_method = requests.post if self.post else requests.get
+        http_method = _SESSION.post if self.post else _SESSION.get
         r = http_method(
             self.url,
             headers={

--- a/siibra/retrieval/requests.py
+++ b/siibra/retrieval/requests.py
@@ -205,7 +205,7 @@ class HttpRequest:
 
         # not yet in cache, perform http request.
         if self.msg_if_not_cached is not None:
-            logger.debug(self.msg_if_not_cached)
+            logger.info(self.msg_if_not_cached)
 
         headers = self.kwargs.get("headers", {})
         other_kwargs = {

--- a/siibra/volumes/providers/neuroglancer.py
+++ b/siibra/volumes/providers/neuroglancer.py
@@ -31,7 +31,6 @@ from ...retrieval import requests, cache
 from ...locations import boundingbox as _boundingbox
 from ...commons import (
     logger,
-    MapType,
     merge_meshes,
     SIIBRA_MAX_FETCH_SIZE_BYTES,
     SIIBRA_NG_VOL_USE_CACHE,
@@ -307,23 +306,6 @@ class NeuroglancerVolume:
             accessor = HttpAccessor(self.url)
             self._io = get_IO_for_existing_dataset(accessor)
         return self._io
-
-    @property
-    def map_type(self):
-        if self._info is None:
-            self._bootstrap()
-        return (
-            MapType.LABELLED
-            if self._info.get("type") == "segmentation"
-            else MapType.STATISTICAL
-        )
-
-    @map_type.setter
-    def map_type(self, val):
-        if val is not None:
-            logger.debug(
-                "NeuroglancerVolume can determine its own maptype from self._info.get('type')"
-            )
 
     def _bootstrap(self):
         self._info = requests.HttpRequest(f"{self.url}/info", func=lambda b: json.loads(b.decode())).get()

--- a/siibra/volumes/providers/neuroglancer.py
+++ b/siibra/volumes/providers/neuroglancer.py
@@ -643,9 +643,9 @@ class NeuroglancerMesh(_provider.VolumeProvider, srctype="neuroglancer/precompme
         self.volume = volume
         self._init_url = resource
         if isinstance(resource, str):
-            self._meshes = {None: self._fragmentinfo(resource)}
+            self._meshes = {None: resource}
         elif isinstance(resource, dict):
-            self._meshes = {n: self._fragmentinfo(u) for n, u in resource.items()}
+            self._meshes = resource
         else:
             raise ValueError(f"Resource specification not understood for {self.__class__.__name__}: {resource}")
 
@@ -665,10 +665,11 @@ class NeuroglancerMesh(_provider.VolumeProvider, srctype="neuroglancer/precompme
         # extract available fragment urls with their names for the given mesh index
         result = {}
 
-        for name, spec in self._meshes.items():
-            mesh_key = spec.get('info', {}).get('mesh')
-            meshurl = f"{spec['url']}/{mesh_key}/{str(meshindex)}:0"
-            transform = spec.get('transform_nm')
+        for name, url in self._meshes.items():
+            fragmentinfo = self._fragmentinfo(url=url)
+            mesh_key = fragmentinfo.get('info', {}).get('mesh')
+            meshurl = f"{fragmentinfo['url']}/{mesh_key}/{str(meshindex)}:0"
+            transform = fragmentinfo.get('transform_nm')
             try:
                 meshinfo = requests.HttpRequest(url=meshurl, func=requests.DECODERS['.json']).data
             except requests.SiibraHttpRequestError:
@@ -683,14 +684,14 @@ class NeuroglancerMesh(_provider.VolumeProvider, srctype="neuroglancer/precompme
                     raise RuntimeError(
                         f"{self.__class__.__name__} was configured with multiple mesh fragments "
                         f"({', '.join(self._meshes.keys())}), but unexpectedly even more fragmentations "
-                        f"were found at {spec['url']}."
+                        f"were found at {fragmentinfo['url']}."
                     )
-                result[name] = (f"{spec['url']}/{mesh_key}/{fragment_names[0]}", transform)
+                result[name] = (f"{fragmentinfo['url']}/{mesh_key}/{fragment_names[0]}", transform)
             else:
                 # only one mesh was configures, so we might still
                 # see multiple fragments under the mesh url
                 for fragment_name in fragment_names:
-                    result[fragment_name] = (f"{spec['url']}/{mesh_key}/{fragment_name}", transform)
+                    result[fragment_name] = (f"{fragmentinfo['url']}/{mesh_key}/{fragment_name}", transform)
 
         return result
 


### PR DESCRIPTION
## Summary

Improve configuration and volume-provider initialization performance by reducing unnecessary HTTP overhead and eager remote metadata access.

### Changes

* Enable `archive_mode` for configuration repositories to avoid fetching configuration files individually.
* Make archive-backed `GithubConnector.search_files()` use the local archive.
* Reuse a shared `requests.Session` in `HttpRequest` to benefit from connection pooling.
* Remove redundant `HttpRequest.data` usage in favor of `get()`.
* Avoid eager Neuroglancer mesh metadata requests during provider construction; fetch fragment metadata lazily when needed.

### Impact

This significantly reduces registry build time, especially for map configurations containing many Neuroglancer providers, by avoiding hundreds of remote requests during object initialization.
